### PR TITLE
Add 3D timeline documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Modify the config.py file to adjust the sensitivity settings and other preferenc
 Contributing
 
 Contributions to the TiRCORDER project are welcome. Please fork the repository, make your changes, and submit a pull request for review.
+## Documentation
+
+See [3D Timeline Axis Priorities](docs/3d_timeline.md) for axis priorities, accessibility, and fallback guidance.
+
 ## License
 
 ITIR and TiRCorder are products of TFYQA.biz provided under [Mozilla Public License - MPL 2.0](https://www.mozilla.org/en-US/MPL/). 

--- a/docs/3d_timeline.md
+++ b/docs/3d_timeline.md
@@ -1,0 +1,30 @@
+# 3D Timeline Axis Priorities
+
+The 3D timeline models how interactions move across platforms and contacts over time. The axes are ordered by importance:
+
+- **X – Platform**: The horizontal axis distinguishes the medium or platform used (e.g., phone, email, social media). Grouping by platform helps analyze cross-channel behavior.
+- **Y – Time**: The vertical axis tracks chronological sequence so trends and gaps become clear.
+- **Z – Contact**: The depth axis separates individual contacts, allowing focused review of each relationship.
+
+## Rationale
+
+Prioritizing platforms on the X-axis keeps similar media aligned, while a vertical time axis communicates progression at a glance. Using depth for contacts allows simultaneous comparison of different relationships without losing temporal context.
+
+## Style Conventions for Axis Emphasis
+
+- Refer to axes in uppercase followed by a colon, e.g., `X:`.
+- Bold axis letters when mentioned in prose (e.g., **X**, **Y**, **Z**).
+- Color suggestions: X = blue, Y = green, Z = red. Ensure colors meet high-contrast guidelines for accessibility.
+
+## Accessibility
+
+- Provide text descriptions and alt text for any 3D visualizations.
+- Offer keyboard navigation and logical reading order for assistive technologies.
+- Choose color palettes with sufficient contrast and avoid relying solely on color to convey meaning.
+
+## Fallback for Non‑3D Environments
+
+- Supply a 2D view using **X** for platform and **Y** for time, encoding contacts through color, icons, or grouping.
+- When graphics are unavailable, present a chronological table grouped by contact.
+- Implement graceful degradation so environments lacking WebGL or 3D support default to the 2D or textual representations automatically.
+


### PR DESCRIPTION
## Summary
- Document 3D timeline axis priorities and design rationale, including accessibility guidance and non‑3D fallbacks.
- Link the new 3D timeline guide from the main README for future contributors.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68968b7214ec832294b375969299ca5d