### PR TITLE
Add sentiment analysis utilities and timeline integration stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ TiRCorder, specifically tailored for professional environments, prioritizes secu
 - **Word-level Confidence Scores**
 - **User-friendly Web Interface --  currently Gradio for API/GUI access, more to come soon**
 - **Streamlined Setup Process -- there are some issues supporting GPGPU on older cards. At time of first commit, AMD GPGPU was not supported on windows, though there appears to be progress being made via WSL.**
+- **Sentiment & Timeline Views -- prototype module for word-level sentiment and time-based aggregation with hooks for external activity sources (YouTube, Google Docs, chat logs, Zapier).**
 
 - A note on development, [AMD has deprecated support for General Purpose compute on older cards such as Polaris (RX580)](https://github.com/lamikr/rocm_sdk_builder/issues/173#issuecomment-2555741882). The community [has been working to restore these features](https://github.com/xuhuisheng/rocm-gfx803). Due to develpment and personal constraints, progress on this project was limited [until recently, with sincere thank yous to those involved in the efforts](https://github.com/robertrosenbusch/gfx803_rocm). As of June 2025, progress may ideally resume!
 

--- a/integrations/chat_history.py
+++ b/integrations/chat_history.py
@@ -1,0 +1,11 @@
+"""Placeholder utilities for importing chat histories from LLM interfaces."""
+from typing import Dict, List
+
+
+def load_chat_history(path: str) -> List[Dict]:
+    """Load chat transcripts from *path*.
+
+    This function is a placeholder which would parse exported conversations
+    from LLM chat interfaces (e.g. ChatGPT, Claude) into timeline events.
+    """
+    raise NotImplementedError("Chat history integration not yet implemented")

--- a/integrations/google_docs.py
+++ b/integrations/google_docs.py
@@ -1,0 +1,13 @@
+"""Stubs for Google Docs/Drive activity integration."""
+from datetime import datetime
+from typing import Dict, List
+
+
+def load_document_activity(credentials, start: datetime, end: datetime) -> List[Dict]:
+    """Fetch activity within the given timeframe.
+
+    This function is intentionally left as a stub.  It serves as a placeholder
+    for future integration with the Google Drive Activity API which would
+    allow TiRCorder to pull in document edits into the user timeline.
+    """
+    raise NotImplementedError("Google Docs integration not yet implemented")

--- a/integrations/youtube_history.py
+++ b/integrations/youtube_history.py
@@ -1,0 +1,48 @@
+"""Parse YouTube watch history exports.
+
+The Google Takeout service allows users to export their YouTube watch history
+as a JSON file.  This helper converts that export into a list of timeline
+events that can be merged with other data sources.
+"""
+import json
+from datetime import datetime
+from typing import Dict, List
+
+
+def load_watch_history(path: str) -> List[Dict]:
+    """Load watch history events from *path*.
+
+    Parameters
+    ----------
+    path:
+        Location of the ``watch-history.json`` file exported from Google
+        Takeout.
+
+    Returns
+    -------
+    list of dict
+        Each event contains ``time`` (as :class:`datetime`), ``title`` and
+        ``url`` keys.
+    """
+
+    with open(path, "r", encoding="utf-8") as fh:
+        raw_items = json.load(fh)
+
+    events: List[Dict] = []
+    for item in raw_items:
+        time_str = item.get("time") or item.get("timestamp")
+        if not time_str:
+            continue
+        try:
+            dt = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
+        except ValueError:
+            # Skip malformed timestamps.
+            continue
+        events.append(
+            {
+                "time": dt,
+                "title": item.get("title", ""),
+                "url": item.get("titleUrl"),
+            }
+        )
+    return events

--- a/integrations/zapier_integration.py
+++ b/integrations/zapier_integration.py
@@ -1,0 +1,28 @@
+"""Minimal Zapier webhook helper."""
+from typing import Dict
+
+import requests
+
+
+def send_event(webhook_url: str, data: Dict) -> bool:
+    """POST *data* to a Zapier "Catch Hook" URL.
+
+    Parameters
+    ----------
+    webhook_url:
+        Zapier generated URL.
+    data:
+        JSON serialisable dictionary payload.
+
+    Returns
+    -------
+    bool
+        ``True`` if the request succeeded, otherwise ``False``.
+    """
+
+    try:
+        response = requests.post(webhook_url, json=data, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException:
+        return False
+    return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ ctranslate2
 faster_whisper
 librosa
 warnings
+vaderSentiment
+requests

--- a/sentiment_analysis.py
+++ b/sentiment_analysis.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+"""Utilities for computing basic sentiment metrics on transcripts.
+
+This module exposes helpers to calculate word-level sentiment as well as
+aggregate sentiment over time blocks (e.g. per hour or per day).  The
+implementation relies on the `vaderSentiment` package which provides a simple
+lexicon and rule-based sentiment analyser.
+
+These functions are intentionally lightweight and operate on plain data
+structures so that higher level interfaces (CLI, GUI, web) can consume the
+results in whatever way makes sense for the TiRCorder project.
+"""
+from dataclasses import dataclass
+from datetime import datetime
+import re
+from typing import Dict, Iterable, List
+
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+_analyser = SentimentIntensityAnalyzer()
+
+
+@dataclass
+class TranscriptSegment:
+    """Represents a fragment of transcript text.
+
+    Attributes
+    ----------
+    start: datetime
+        Absolute start time of the segment.
+    end: datetime
+        Absolute end time of the segment.
+    text: str
+        Transcribed text for the segment.
+    """
+
+    start: datetime
+    end: datetime
+    text: str
+
+
+def word_sentiments(text: str) -> List[Dict[str, float]]:
+    """Return sentiment scores for each word in *text*.
+
+    Parameters
+    ----------
+    text:
+        Raw transcript text.
+
+    Returns
+    -------
+    list of dict
+        Each entry has the keys ``word`` and ``score`` (compound sentiment
+        score ranging from -1..1).
+    """
+
+    words = re.findall(r"\w+", text)
+    return [{"word": w, "score": _analyser.polarity_scores(w)["compound"]} for w in words]
+
+
+def aggregate_sentiment(
+    segments: Iterable[TranscriptSegment], *, level: str = "hour"
+) -> Dict[datetime, float]:
+    """Aggregate sentiment for *segments* grouped by time blocks.
+
+    Parameters
+    ----------
+    segments:
+        Iterable of :class:`TranscriptSegment` items.
+    level:
+        Either ``"hour"`` or ``"day"`` determining the aggregation bucket.
+
+    Returns
+    -------
+    dict
+        Mapping bucket start timestamps to mean compound sentiment score.
+    """
+
+    buckets: Dict[datetime, List[float]] = {}
+    for seg in segments:
+        if level == "day":
+            bucket = seg.start.replace(hour=0, minute=0, second=0, microsecond=0)
+        else:  # default to hour resolution
+            bucket = seg.start.replace(minute=0, second=0, microsecond=0)
+        buckets.setdefault(bucket, []).append(_analyser.polarity_scores(seg.text)["compound"])
+
+    return {k: sum(v) / len(v) for k, v in buckets.items() if v}

--- a/timeline.py
+++ b/timeline.py
@@ -1,0 +1,45 @@
+"""Simple helpers for building activity timelines.
+
+Timelines merge events from multiple data sources (audio transcripts, web
+activity, etc.) into a single chronologically ordered stream.  Each event is a
+dictionary with at least a ``time`` field.
+"""
+from datetime import datetime
+from typing import Dict, Iterable, List, Mapping
+
+
+def merge_event_streams(event_streams: Mapping[str, Iterable[Dict]]) -> List[Dict]:
+    """Merge streams from different sources into a single sorted list.
+
+    Parameters
+    ----------
+    event_streams:
+        Mapping of source name to an iterable of event dictionaries.  Each
+        event must contain a ``time`` key with a :class:`datetime` value.
+
+    Returns
+    -------
+    list of dict
+        Combined events tagged with their ``source`` and sorted by ``time``.
+    """
+
+    events: List[Dict] = []
+    for source, stream in event_streams.items():
+        for event in stream:
+            item = dict(event)
+            item["source"] = source
+            events.append(item)
+    events.sort(key=lambda e: e.get("time", datetime.min))
+    return events
+
+
+def bucket_by_day(events: Iterable[Dict]) -> Dict[datetime, List[Dict]]:
+    """Group events into day buckets to enable zoomed-out views."""
+    buckets: Dict[datetime, List[Dict]] = {}
+    for event in events:
+        time = event.get("time")
+        if not isinstance(time, datetime):
+            continue
+        key = time.replace(hour=0, minute=0, second=0, microsecond=0)
+        buckets.setdefault(key, []).append(event)
+    return buckets


### PR DESCRIPTION
## Summary
- introduce `sentiment_analysis` module for word-level and aggregated sentiment metrics
- provide basic timeline helpers and stubs for external data sources (YouTube history, Google Docs, chat logs, Zapier)
- document upcoming sentiment/timeline features and add required dependencies

## Testing
- `python3 -m py_compile sentiment_analysis.py timeline.py integrations/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6898296813a08322aec2ae5db666dfb4