### PR TITLE
Add 3D timeline support with fallback

### DIFF
--- a/Pelican/scripts.js
+++ b/Pelican/scripts.js
@@ -1,3 +1,30 @@
+function supports3d() {
+    const css3d = !!window.CSS && CSS.supports('transform-style', 'preserve-3d');
+    let webgl = false;
+    try {
+        const canvas = document.createElement('canvas');
+        webgl = !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+    } catch (e) {
+        webgl = false;
+    }
+    return css3d || webgl;
+}
+
+function initTimeline3DIfSupported() {
+    if (!supports3d()) {
+        return;
+    }
+
+    const script = document.createElement('script');
+    script.src = 'timeline3d.js';
+    script.onload = function() {
+        if (typeof window.initTimeline3D === 'function') {
+            window.initTimeline3D();
+        }
+    };
+    document.body.appendChild(script);
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     const timelineItems = document.querySelectorAll(".timeline-item");
 
@@ -57,5 +84,7 @@ document.addEventListener("DOMContentLoaded", function() {
             }).join('\n');
         });
     });
+
+    initTimeline3DIfSupported();
 });
 

--- a/Pelican/styles.css
+++ b/Pelican/styles.css
@@ -21,6 +21,15 @@ h1, h2, h3 {
     border-left: 3px solid #333;
 }
 
+.timeline-3d-container {
+    perspective: 800px;
+    transform-style: preserve-3d;
+}
+
+.timeline-3d-container .timeline-item {
+    transform-style: preserve-3d;
+}
+
 .timeline-item {
     position: relative;
     margin: 10px 0;

--- a/Pelican/timeline3d.js
+++ b/Pelican/timeline3d.js
@@ -1,0 +1,21 @@
+(function() {
+    function initTimeline3D() {
+        var container = document.querySelector('.timeline-container');
+        if (!container) {
+            return;
+        }
+
+        container.classList.add('timeline-3d-container');
+
+        var items = container.querySelectorAll('.timeline-item');
+        var depthStep = 100;
+        var z = 0;
+
+        items.forEach(function(item) {
+            item.style.transform = 'translateZ(' + z + 'px)';
+            z -= depthStep;
+        });
+    }
+
+    window.initTimeline3D = initTimeline3D;
+})();


### PR DESCRIPTION
## Summary
- Add `timeline3d.js` to render timeline items in 3D using CSS transforms
- Enhance `scripts.js` to detect 3D capabilities and load the 3D timeline when supported
- Style 3D timeline container with perspective and preserve existing 2D fallback

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68983848197083228ea52eacffb53498