### PR TITLE
Add banking statement parsing plugins

### DIFF
--- a/docs/financial_timeline.md
+++ b/docs/financial_timeline.md
@@ -1,0 +1,32 @@
+# Financial Timeline Vision
+
+## One-liner
+A Sankey-style financial timeline that tells the story of someone’s money: a single vertical ribbon for the main account, with smooth, proportional branches that peel off at key moments and link to life events.
+
+## Product vision
+Show how money moves, when it moves, and why—by lining up transactions with a person’s narrative (jobs, purchases, bills, milestones). It’s part ribbon-timeline, part Sankey, part life-story map. The tone is elegant, infographic-grade (soft gradients, gentle curves, minimal chrome).
+
+## Core experience
+- **Main ribbon (time ↓):** Width expands on income, narrows as funds leave.
+- **Branches ("siphons"):** Curved streams that split from the ribbon, sized by amount, coloured by destination.
+- **Events as anchors:** Floating cards (“Got paid”, “Tax bill”, “Bought equipment”) pinned to the exact moment; branches align to these when relevant.
+- **Multi-account layers (z-depth):** Extra accounts (cheque, savings, business, credit card) appear on visual layers behind/in front of the main ribbon; each has a distinct colour family so siphons are instantly recognisable.
+- **Story first:** Read top-to-bottom like a narrative; numbers support the story rather than overwhelm it.
+
+## Views & clarity
+- **Time as the spine:** The vertical axis is always time.
+- **Colour = destination/account:** Consistent hues across screens.
+- **Depth = account layer:** Foreground for day-to-day, mid for savings, deeper for business/credit.
+- **Calm labels:** Short, rounded callouts that never clutter; overlapping labels gently nudge apart.
+
+## Light analysis (non-technical)
+- **Story alignment:** “This purchase belongs to Bought equipment (80% confidence). Want to link it?”
+- **Flow highlights:** “Savings siphoned 24% of last month’s income.”
+- **Flags:** “Tax branch grew faster than usual in Q3.”
+- **What-if scrubbing:** Drag a marker on the timeline to see balances and committed outflows at that moment.
+
+## Tone & aesthetics
+Clean, premium, presentation-ready. Smooth ribbons, soft gradients, subtle shadows for depth; no harsh edges. Think “Apple-keynote infographic,” not “finance dashboard.”
+
+## Elevator pitch
+We’re building a Sankey-style financial timeline that shows a person’s money as one flowing ribbon with proportional branches that peel off at the exact moments life events happen. It connects bank data to the user’s story so you can literally see how income turns into savings, purchases, repayments, and taxes over time.

--- a/integrations/accounting/__init__.py
+++ b/integrations/accounting/__init__.py
@@ -1,0 +1,26 @@
+"""Plugins for importing data from account management software."""
+
+from .base import AccountPlugin
+
+try:  # Optional dependency
+    from .firefly_plugin import FireflyIIIPlugin
+except Exception:  # pragma: no cover - dependency not installed
+    FireflyIIIPlugin = None  # type: ignore
+
+try:
+    from .gnucash_plugin import GnuCashPlugin
+except Exception:  # pragma: no cover - dependency not installed
+    GnuCashPlugin = None  # type: ignore
+
+from .kmymoney_plugin import KMyMoneyPlugin
+from .moneymanagerex_plugin import MoneyManagerExPlugin
+from .quicken_plugin import QuickenPlugin
+
+__all__ = [
+    "AccountPlugin",
+    "FireflyIIIPlugin",
+    "GnuCashPlugin",
+    "KMyMoneyPlugin",
+    "MoneyManagerExPlugin",
+    "QuickenPlugin",
+]

--- a/integrations/accounting/base.py
+++ b/integrations/accounting/base.py
@@ -1,0 +1,12 @@
+"""Base classes for account management integrations."""
+from typing import List
+
+from ..banking import Transaction
+
+
+class AccountPlugin:
+    """Interface for importing transactions from account managers."""
+
+    def fetch_transactions(self, *args, **kwargs) -> List[Transaction]:  # pragma: no cover - interface
+        """Return a list of :class:`~integrations.banking.Transaction` objects."""
+        raise NotImplementedError

--- a/integrations/accounting/firefly_plugin.py
+++ b/integrations/accounting/firefly_plugin.py
@@ -1,0 +1,44 @@
+"""Integration with the Firefly-III personal finance manager."""
+from datetime import datetime
+from typing import List
+
+import requests
+
+from .base import AccountPlugin
+from ..banking import Transaction
+
+
+class FireflyIIIPlugin(AccountPlugin):
+    """Fetch transactions from a Firefly-III instance using its REST API."""
+
+    def __init__(self, base_url: str, token: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"Bearer {token}"})
+
+    def fetch_transactions(self, start: datetime, end: datetime) -> List[Transaction]:
+        params = {"start": start.date().isoformat(), "end": end.date().isoformat()}
+        url = f"{self.base_url}/api/v1/transactions"
+        resp = self.session.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        payload = resp.json()
+        transactions: List[Transaction] = []
+        for item in payload.get("data", []):
+            attrs = item.get("attributes", {})
+            for tx in attrs.get("transactions", []):
+                try:
+                    dt = datetime.fromisoformat(tx["date"])
+                    amount = float(tx["amount"])
+                except (KeyError, ValueError):
+                    continue
+                transactions.append(
+                    Transaction(
+                        date=dt,
+                        amount=amount,
+                        currency=tx.get("currency_code", ""),
+                        description=tx.get("description", ""),
+                        source_account=tx.get("source_name", ""),
+                        destination_account=tx.get("destination_name"),
+                    )
+                )
+        return transactions

--- a/integrations/accounting/gnucash_plugin.py
+++ b/integrations/accounting/gnucash_plugin.py
@@ -1,0 +1,34 @@
+"""Import transactions from a GnuCash book file."""
+from datetime import datetime
+from typing import List, Optional
+
+from piecash import open_book
+
+from .base import AccountPlugin
+from ..banking import Transaction
+
+
+class GnuCashPlugin(AccountPlugin):
+    """Read transactions from a local GnuCash file using :mod:`piecash`."""
+
+    def fetch_transactions(
+        self, path: str, start: Optional[datetime] = None, end: Optional[datetime] = None
+    ) -> List[Transaction]:
+        with open_book(path) as book:
+            transactions: List[Transaction] = []
+            for tx in book.transactions:
+                if start and tx.post_date < start:
+                    continue
+                if end and tx.post_date > end:
+                    continue
+                for split in tx.splits:
+                    transactions.append(
+                        Transaction(
+                            date=tx.post_date,
+                            amount=float(split.value),
+                            currency=split.account.commodity.mnemonic,
+                            description=tx.description or "",
+                            source_account=split.account.fullname,
+                        )
+                    )
+        return transactions

--- a/integrations/accounting/kmymoney_plugin.py
+++ b/integrations/accounting/kmymoney_plugin.py
@@ -1,0 +1,38 @@
+"""Parse transactions from KMyMoney XML files."""
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import List
+
+from .base import AccountPlugin
+from ..banking import Transaction
+
+
+class KMyMoneyPlugin(AccountPlugin):
+    """Load transactions from the ``.kmy`` XML format used by KMyMoney."""
+
+    def fetch_transactions(self, path: str) -> List[Transaction]:
+        tree = ET.parse(path)
+        root = tree.getroot()
+        ns = {"kmm": root.tag.split('}')[0].strip('{')} if root.tag.startswith('{') else {}
+        transactions: List[Transaction] = []
+        for tx in root.findall('.//kmm:TRANSACTION', ns):
+            date_str = tx.get('postdate')
+            if not date_str:
+                continue
+            try:
+                dt = datetime.strptime(date_str, '%Y-%m-%d')
+            except ValueError:
+                continue
+            memo = tx.get('memo', '')
+            for split in tx.findall('kmm:SPLITS/kmm:SPLIT', ns):
+                amount = float(split.get('value', '0').replace(',', '.'))
+                account = split.get('account', '')
+                transactions.append(
+                    Transaction(
+                        date=dt,
+                        amount=amount,
+                        description=memo,
+                        source_account=account,
+                    )
+                )
+        return transactions

--- a/integrations/accounting/moneymanagerex_plugin.py
+++ b/integrations/accounting/moneymanagerex_plugin.py
@@ -1,0 +1,35 @@
+"""Read transactions from MoneyManagerEx database."""
+import sqlite3
+from datetime import datetime
+from typing import List
+
+from .base import AccountPlugin
+from ..banking import Transaction
+
+
+class MoneyManagerExPlugin(AccountPlugin):
+    """Load transaction rows from the MoneyManagerEx SQLite database."""
+
+    def fetch_transactions(self, db_path: str) -> List[Transaction]:
+        conn = sqlite3.connect(db_path)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT TRANSDATE, AMOUNT, MEMO FROM CHECKINGACCOUNT_V1"
+        )
+        rows = cur.fetchall()
+        conn.close()
+        transactions: List[Transaction] = []
+        for date_str, amount, memo in rows:
+            try:
+                dt = datetime.strptime(date_str, "%Y-%m-%d")
+            except ValueError:
+                continue
+            transactions.append(
+                Transaction(
+                    date=dt,
+                    amount=float(amount),
+                    description=memo or "",
+                    source_account="checking",
+                )
+            )
+        return transactions

--- a/integrations/accounting/quicken_plugin.py
+++ b/integrations/accounting/quicken_plugin.py
@@ -1,0 +1,16 @@
+"""Adapter for importing Quicken data via QIF exports."""
+from typing import List
+
+from .base import AccountPlugin
+from ..banking import Transaction
+from ..banking.qif_plugin import QIFPlugin
+
+
+class QuickenPlugin(AccountPlugin):
+    """Leverage the existing QIF parser to read Quicken statements."""
+
+    def __init__(self) -> None:
+        self._parser = QIFPlugin()
+
+    def fetch_transactions(self, path: str) -> List[Transaction]:
+        return self._parser.parse_file(path)

--- a/integrations/banking/__init__.py
+++ b/integrations/banking/__init__.py
@@ -1,0 +1,17 @@
+"""Bank statement parsing plugins."""
+
+from .base import (
+    BankingPlugin,
+    Transaction,
+    link_transactions_to_events,
+    transactions_to_events,
+    transaction_to_event,
+)
+
+__all__ = [
+    "BankingPlugin",
+    "Transaction",
+    "transaction_to_event",
+    "transactions_to_events",
+    "link_transactions_to_events",
+]

--- a/integrations/banking/base.py
+++ b/integrations/banking/base.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+@dataclass
+class Transaction:
+    """Represents a single money movement between accounts."""
+
+    date: datetime
+    amount: float
+    currency: str = ""
+    description: str = ""
+    source_account: str = ""
+    destination_account: Optional[str] = None
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+
+def transaction_to_event(tx: Transaction) -> Dict:
+    """Convert a :class:`Transaction` into a timeline event dictionary."""
+    event = {
+        "time": tx.date,
+        "label": tx.description or "Transaction",
+        "amount": tx.amount,
+        "currency": tx.currency,
+        "source_account": tx.source_account,
+        "destination_account": tx.destination_account,
+    }
+    if tx.metadata:
+        event["metadata"] = tx.metadata
+    return event
+
+
+def transactions_to_events(transactions: Iterable[Transaction]) -> List[Dict]:
+    """Turn a list of transactions into timeline events."""
+    return [transaction_to_event(tx) for tx in transactions]
+
+
+def link_transactions_to_events(
+    transactions: Sequence[Transaction],
+    events: Sequence[Dict],
+    tolerance: timedelta = timedelta(hours=1),
+) -> List[Tuple[Transaction, Optional[Dict]]]:
+    """Associate each transaction with a nearby timeline event.
+
+    Parameters
+    ----------
+    transactions:
+        Ordered sequence of transactions.
+    events:
+        Timeline events sorted by time.
+    tolerance:
+        Maximum distance between transaction time and event time for them to be
+        considered linked.
+
+    Returns
+    -------
+    list of tuple
+        List of ``(transaction, event)`` pairs.  ``event`` will be ``None`` if
+        no suitable match is found within the tolerance window.
+    """
+    linked: List[Tuple[Transaction, Optional[Dict]]] = []
+    for tx in transactions:
+        match: Optional[Dict] = None
+        for ev in events:
+            tdiff = abs(ev.get("time") - tx.date)
+            if tdiff <= tolerance:
+                match = ev
+                break
+        linked.append((tx, match))
+    return linked
+
+
+class BankingPlugin:
+    """Base class for bank statement parsers."""
+
+    def parse_file(self, path: str) -> List[Transaction]:  # pragma: no cover - interface
+        """Parse the given file and return a list of transactions."""
+        raise NotImplementedError

--- a/integrations/banking/csv_plugin.py
+++ b/integrations/banking/csv_plugin.py
@@ -1,0 +1,31 @@
+"""Parser for simple CSV bank statements."""
+from datetime import datetime
+from typing import List
+import csv
+
+from .base import BankingPlugin, Transaction
+
+
+class CSVBankingPlugin(BankingPlugin):
+    """Parse CSV files with columns like date, amount, description, etc."""
+
+    def parse_file(self, path: str) -> List[Transaction]:
+        transactions: List[Transaction] = []
+        with open(path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                try:
+                    date = datetime.fromisoformat(row.get("date", ""))
+                except ValueError:
+                    continue
+                amount = float(row.get("amount", 0))
+                tx = Transaction(
+                    date=date,
+                    amount=amount,
+                    currency=row.get("currency", ""),
+                    description=row.get("description", ""),
+                    source_account=row.get("source_account", ""),
+                    destination_account=row.get("destination_account") or None,
+                )
+                transactions.append(tx)
+        return transactions

--- a/integrations/banking/iso20022_plugin.py
+++ b/integrations/banking/iso20022_plugin.py
@@ -1,0 +1,38 @@
+"""Parser for ISO 20022 (camt.053) XML statements."""
+from datetime import datetime
+from typing import List
+import xml.etree.ElementTree as ET
+
+from .base import BankingPlugin, Transaction
+
+
+class ISO20022BankingPlugin(BankingPlugin):
+    """Parse ISO 20022 XML files for basic transaction data."""
+
+    def parse_file(self, path: str) -> List[Transaction]:
+        tree = ET.parse(path)
+        root = tree.getroot()
+        ns = {"ns": root.tag.split("}")[0].strip("{")}
+        tx_nodes = root.findall(
+            ".//ns:Ntry/ns:NtryDtls/ns:TxDtls", ns
+        )  # typical camt.053 path
+        transactions: List[Transaction] = []
+        for node in tx_nodes:
+            amt_node = node.find("ns:Amt", ns)
+            date_node = node.find("ns:BookgDt/ns:Dt", ns)
+            descr_node = node.find("ns:RmtInf/ns:Ustrd", ns)
+            if amt_node is None or date_node is None:
+                continue
+            currency = amt_node.attrib.get("Ccy", "")
+            amount = float(amt_node.text or 0)
+            date = datetime.fromisoformat(date_node.text)
+            description = descr_node.text if descr_node is not None else ""
+            transactions.append(
+                Transaction(
+                    date=date,
+                    amount=amount,
+                    currency=currency,
+                    description=description,
+                )
+            )
+        return transactions

--- a/integrations/banking/json_plugin.py
+++ b/integrations/banking/json_plugin.py
@@ -1,0 +1,31 @@
+"""Parser for JSON-based bank statement exports."""
+from datetime import datetime
+from typing import List
+import json
+
+from .base import BankingPlugin, Transaction
+
+
+class JSONBankingPlugin(BankingPlugin):
+    """Parse JSON files with a list of transactions."""
+
+    def parse_file(self, path: str) -> List[Transaction]:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        items = data.get("transactions") if isinstance(data, dict) else data
+        transactions: List[Transaction] = []
+        for row in items:
+            try:
+                date = datetime.fromisoformat(row.get("date", ""))
+            except ValueError:
+                continue
+            tx = Transaction(
+                date=date,
+                amount=float(row.get("amount", 0)),
+                currency=row.get("currency", ""),
+                description=row.get("description", ""),
+                source_account=row.get("source_account", ""),
+                destination_account=row.get("destination_account") or None,
+            )
+            transactions.append(tx)
+        return transactions

--- a/integrations/banking/ofx_plugin.py
+++ b/integrations/banking/ofx_plugin.py
@@ -1,0 +1,31 @@
+"""Parser for OFX (Open Financial Exchange) statements."""
+from typing import List
+
+from .base import BankingPlugin, Transaction
+
+
+class OFXBankingPlugin(BankingPlugin):
+    """Parse OFX files using the ``ofxparse`` library."""
+
+    def parse_file(self, path: str) -> List[Transaction]:
+        try:
+            from ofxparse import OfxParser  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("ofxparse library is required for OFX support") from exc
+
+        with open(path, "rb") as fh:
+            ofx = OfxParser.parse(fh)
+
+        transactions: List[Transaction] = []
+        for account in ofx.accounts:
+            for tx in account.statement.transactions:
+                transactions.append(
+                    Transaction(
+                        date=tx.date,
+                        amount=tx.amount,
+                        currency=account.statement.currency or "",
+                        description=tx.memo or "",
+                        source_account=account.account_id,
+                    )
+                )
+        return transactions

--- a/integrations/banking/qif_plugin.py
+++ b/integrations/banking/qif_plugin.py
@@ -1,0 +1,30 @@
+"""Parser for QIF (Quicken Interchange Format) files."""
+from typing import List
+
+from .base import BankingPlugin, Transaction
+
+
+class QIFBankingPlugin(BankingPlugin):
+    """Parse QIF files using the ``qifparse`` library."""
+
+    def parse_file(self, path: str) -> List[Transaction]:
+        try:
+            import qifparse.parser as qifparser  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("qifparse library is required for QIF support") from exc
+
+        with open(path, "r", encoding="utf-8") as fh:
+            qif = qifparser.QifParser.parse(fh)
+
+        transactions: List[Transaction] = []
+        for tx in qif.get_transactions():
+            transactions.append(
+                Transaction(
+                    date=tx.date,
+                    amount=tx.amount,
+                    currency="",
+                    description=tx.memo or "",
+                    source_account=tx.account or "",
+                )
+            )
+        return transactions

--- a/integrations/google_search_history.py
+++ b/integrations/google_search_history.py
@@ -1,0 +1,46 @@
+"""Parse Google search history exports."""
+import json
+from datetime import datetime
+from typing import Dict, List
+
+
+def load_search_history(path: str) -> List[Dict]:
+    """Load search queries from a Google Takeout JSON export.
+
+    Parameters
+    ----------
+    path:
+        Location of the ``Search-history.json`` file from Google Takeout.
+
+    Returns
+    -------
+    list of dict
+        Each event contains ``time`` (as :class:`datetime`), ``query`` and
+        optional ``url`` keys.
+    """
+
+    with open(path, "r", encoding="utf-8") as fh:
+        raw_items = json.load(fh)
+
+    events: List[Dict] = []
+    for item in raw_items:
+        time_str = item.get("time") or item.get("timestamp")
+        if not time_str:
+            continue
+        try:
+            dt = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        title = item.get("title", "")
+        if title.startswith("Searched for"):
+            query = title.replace("Searched for", "").strip().strip('"')
+        else:
+            query = title
+        events.append(
+            {
+                "time": dt,
+                "query": query,
+                "url": item.get("titleUrl"),
+            }
+        )
+    return events

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ vaderSentiment
 requests
 ofxparse
 qifparse
+
+piecash

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ librosa
 warnings
 vaderSentiment
 requests
+ofxparse
+qifparse


### PR DESCRIPTION
## Summary
- add banking transaction data model and utilities for timeline linking
- implement CSV, JSON, OFX, QIF, and ISO20022 parsers
- declare plugin dependencies

## Testing
- `PYTHONPATH=. PYENV_VERSION=3.10.17 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68983f62fcb88322a6e73f129e60e4f5