### PR TITLE
Add accessibility documentation and review website generator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS
+
+## Code Style
+- Follow PEP 8 with Black formatting (line length 88).
+- Use 4-space indentation and include docstrings for public functions.
+
+## Testing
+Run tests before committing:
+
+```
+PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q
+```
+
+## Pull Requests
+Include a summary of changes and the test command output in PR descriptions.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ Contributions to the TiRCORDER project are welcome. Please fork the repository, 
 
 See [3D Timeline Axis Priorities](docs/3d_timeline.md) for axis priorities, accessibility, and fallback guidance.
 
+## Accessibility
+
+The generated web interface uses semantic HTML and provides transcripts for audio clips,
+but it currently lacks ARIA roles, skip-navigation links, and other enhancements that
+improve screen‑reader and keyboard support. We document implemented accessibility tools
+and a TODO roadmap in [accessibility.md](accessibility.md) and welcome community
+feedback as we work toward WCAG 2.1 AA compliance.
+
 ## License
 
 ITIR and TiRCorder are products of TFYQA.biz provided under [Mozilla Public License - MPL 2.0](https://www.mozilla.org/en-US/MPL/). 

--- a/accessibility.md
+++ b/accessibility.md
@@ -1,0 +1,36 @@
+# Accessibility
+
+We are committed to building interfaces that everyone can use. Our minimum commitments include:
+
+- Follow the [Web Content Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) 2.1 at the AA level.
+- Provide text alternatives for non-text content, including transcripts for audio.
+- Maintain keyboard navigability and logical focus order.
+- Preserve sufficient color contrast and responsive layouts.
+- Continue testing with assistive technologies and incorporate user feedback.
+
+## Current status
+
+The generated timeline page uses semantic HTML elements such as `<header>`, `<main>`, `<section>` and `<audio>`, and exposes text transcripts for audio clips. However, it currently lacks ARIA attributes, skip-navigation links, and other patterns that help screen‑reader users understand interactive elements. Keyboard focus indicators and announcements for dynamically displayed content also need improvement.
+
+## Implemented accessibility features
+
+- Semantic landmarks (`<header>`, `<main>`, `<section>`) structure content.
+- Audio clips include `<audio>` players paired with text transcripts.
+- Layouts respond to different screen sizes while preserving color contrast.
+
+## Accessibility TODO
+
+- Add ARIA roles and labels to interactive controls.
+- Introduce skip-navigation links for keyboard users.
+- Provide visible focus styles and announce dynamic updates with `aria-live`.
+- Automate audits with tools like axe-core and Lighthouse.
+- Expand manual testing with screen readers and alternate input devices.
+
+## Accessibility on the Web in 2025
+
+Despite progress, accessibility remains a major challenge on the wider web. The
+[2025 WebAIM Million report](https://webaim.org/projects/million/) continues to
+find that **over 90% of popular sites fail basic WCAG tests**. This reinforces
+the importance of treating accessibility as a first-class requirement.
+
+We will update this document as our work evolves.


### PR DESCRIPTION
## Summary
- document minimum accessibility commitments and the state of the wider web in 2025
- link README to accessibility guidelines and roadmap
- review website generator to note existing semantic markup and missing ARIA/keyboard features
- add AGENTS.md with code style, testing, and PR instructions
- enumerate implemented accessibility tools and outline TODOs like ARIA roles, skip links, and audits
- wrap README accessibility section and cite WebAIM report on 90% failure rate

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898733ef094832297e432c78a6ef7a5