### PR TITLE
Add skeleton for Australian My Health Record connector

### DIFF
--- a/integrations/medical/__init__.py
+++ b/integrations/medical/__init__.py
@@ -1,0 +1,10 @@
+"""Connectors for national medical record systems."""
+
+from .base import MedicalRecordConnector
+from .my_health_record import MyHealthRecordConnector
+
+CONNECTORS = {
+    "AU": MyHealthRecordConnector,
+}
+
+__all__ = ["MedicalRecordConnector", "MyHealthRecordConnector", "CONNECTORS"]

--- a/integrations/medical/base.py
+++ b/integrations/medical/base.py
@@ -1,0 +1,18 @@
+"""Base classes for national medical record connectors."""
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class MedicalRecordConnector(ABC):
+    """Interface for national medical record systems."""
+
+    @abstractmethod
+    def authenticate(self, **credentials) -> None:
+        """Authenticate with the remote service."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def fetch_records(self, patient_id: str) -> Dict:
+        """Return patient records in FHIR format."""
+        raise NotImplementedError

--- a/integrations/medical/my_health_record.py
+++ b/integrations/medical/my_health_record.py
@@ -1,0 +1,22 @@
+"""Connector for Australia's My Health Record."""
+
+from typing import Dict, Optional
+
+from .base import MedicalRecordConnector
+
+
+class MyHealthRecordConnector(MedicalRecordConnector):
+    """Retrieve records from the Australian My Health Record system."""
+
+    def __init__(self) -> None:
+        self.token: Optional[str] = None
+
+    def authenticate(self, token: str) -> None:
+        """Store API token for subsequent requests."""
+        self.token = token
+
+    def fetch_records(self, patient_id: str) -> Dict:
+        """Fetch patient records in FHIR format."""
+        raise NotImplementedError(
+            "My Health Record API integration not yet implemented"
+        )

--- a/tests/test_medical_record_connector.py
+++ b/tests/test_medical_record_connector.py
@@ -1,0 +1,15 @@
+import pytest
+
+from integrations.medical import MyHealthRecordConnector
+
+
+def test_authenticate_stores_token():
+    connector = MyHealthRecordConnector()
+    connector.authenticate("secret")
+    assert connector.token == "secret"
+
+
+def test_fetch_records_not_implemented():
+    connector = MyHealthRecordConnector()
+    with pytest.raises(NotImplementedError):
+        connector.fetch_records("patient")


### PR DESCRIPTION
## Summary
- establish medical record connector interface
- add My Health Record connector skeleton and registry entry
- test token storage and placeholder fetch method

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_medical_record_connector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68987a5d1f808322927e3944fec3b333