### PR TITLE
Add Plotly-based Sankey renderer and demo

### DIFF
--- a/docs/ribbon_timeline_goals.md
+++ b/docs/ribbon_timeline_goals.md
@@ -1,0 +1,26 @@
+# Ribbon Timeline Visualisation Goals
+
+The ribbon timeline aims to present financial flows on a website in a way that is:
+
+- **Website first and responsive** – diagrams adapt to container size for embedding in modern layouts.
+- **Narrative-friendly** – transaction events can be annotated to tell the story behind each transfer.
+- **Depth-aware** – accounts are layered by logical importance to guide the reader's eye.
+
+## Comparison with Existing Tools
+
+| Feature / Aspect | Typical Accounting & Case Management Software | Existing Visualisation Tools (i2, Maltego, Linkurious) | Ribbon Timeline Concept |
+| --- | --- | --- | --- |
+| Primary Goal | Accurate recordkeeping, double-entry compliance | Relationship mapping, case links, or static Sankey diagrams | Storytelling of money flows over time linked to life events |
+| Visual Focus | Tables, bar charts, pie charts | Node-link diagrams, blocky flow charts | Continuous, organic ribbon that changes width with inflow/outflow |
+| Time Dimension | Dates as table fields or X-axis in charts | Sometimes via timelines, often separate from graph view | Time is the spine (vertical axis), every flow anchored to its moment |
+| Multi-Account View | Separate ledgers or tabbed reports | Can merge datasets, but visually flat | Z-depth layering for accounts (cheque, savings, business, credit) |
+| Outflow Representation | Line items in reports | Fixed-width arrows or edges | Proportional branch thickness, smooth siphons showing exact share of main ribbon |
+| Pattern Recognition | Requires reading numbers or filtering | Cluster analysis, graph layout | Visual "standout" of large or suspicious flows — instant at-a-glance cues |
+| Narrative Integration | Notes/comments fields | Manual annotation or separate reports | Event cards pinned to exact transaction points, telling the why as well as the where |
+| Aesthetic Quality | Functional, minimal | Analyst-oriented | Infographic-grade: soft gradients, curves, clean depth for persuasive presentations |
+| Ease for Non-Technical Lawyers | High (but dry presentation) | Medium — needs graph literacy | High once explained; reads like a visual story instead of a chart |
+| Court/Stakeholder Impact | Limited — numbers heavy | Good for showing links, but may overwhelm | Strong — blends data accuracy with visual clarity for non-specialist audiences |
+
+## Why This Doesn't Already Exist
+
+Most accounting packages prioritise ledger accuracy, while investigative tools focus on relationship graphs. Neither tries to weave a coherent narrative of money over time. The ribbon timeline fills this gap by combining responsive web visuals with intuitive depth cues so that flows make sense to analysts and lay audiences alike.

--- a/docs/sankey_render_demo.ipynb
+++ b/docs/sankey_render_demo.ipynb
@@ -1,0 +1,31 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from visualisation.sankey_render import AccountStyle, Flow, render_sankey\n",
+    "flows = [\n",
+    "    Flow('Income', 'Savings', 1000, AccountStyle('#2ca02c', 0.0), AccountStyle('#1f77b4', 0.5))\n",
+    "]\n",
+    "render_sankey(flows, 'example_sankey.html')\n",
+    "print('Generated example_sankey.html')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ ofxparse
 qifparse
 
 piecash
+plotly

--- a/tests/test_sankey_render.py
+++ b/tests/test_sankey_render.py
@@ -1,0 +1,27 @@
+from visualisation.sankey_render import AccountStyle, Flow, render_sankey
+
+
+def test_render_sankey_creates_html(tmp_path):
+    flows = [
+        Flow(
+            source="Income",
+            target="Savings",
+            value=1000,
+            source_style=AccountStyle(color="#2ca02c", depth=0.0),
+            target_style=AccountStyle(color="#1f77b4", depth=0.5),
+        ),
+        Flow(
+            source="Savings",
+            target="Expenses",
+            value=500,
+            source_style=AccountStyle(color="#1f77b4", depth=0.5),
+            target_style=AccountStyle(color="#d62728", depth=1.0),
+        ),
+    ]
+    output_file = tmp_path / "sankey.html"
+    render_sankey(flows, str(output_file))
+    assert output_file.exists()
+    # Basic sanity check on output contents
+    text = output_file.read_text()
+    # The file should contain an embeddable Plotly div rather than a full HTML page
+    assert "<div" in text.lower()

--- a/visualisation/sankey_render.py
+++ b/visualisation/sankey_render.py
@@ -1,0 +1,101 @@
+"""Utilities for rendering Sankey diagrams from accounting flows.
+
+This module relies on Plotly to generate an interactive HTML visualisation.
+It expects the ``generate_sankey`` function to supply a list of ``Flow``
+objects describing transfers between accounts.  Each account has an associated
+``AccountStyle`` that defines its colour and logical depth in the diagram.
+
+Example usage::
+
+    flows = [
+        Flow(
+            source="Income",
+            target="Savings",
+            value=1000,
+            source_style=AccountStyle(color="#2ca02c", depth=0.0),
+            target_style=AccountStyle(color="#1f77b4", depth=0.5),
+        ),
+    ]
+    render_sankey(flows, "out.html")
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import plotly.graph_objects as go
+
+
+@dataclass(frozen=True)
+class AccountStyle:
+    """Visual properties for an account node."""
+
+    color: str
+    depth: float  # Normalised position (0.0-1.0) in the diagram
+
+
+@dataclass(frozen=True)
+class Flow:
+    """Represents a transfer between two accounts."""
+
+    source: str
+    target: str
+    value: float
+    source_style: AccountStyle
+    target_style: AccountStyle
+
+
+def render_sankey(flows: Iterable[Flow], output_path: str) -> Path:
+    """Render a Sankey diagram to ``output_path``.
+
+    Parameters
+    ----------
+    flows:
+        Iterable of :class:`Flow` objects typically produced by
+        ``generate_sankey``.
+    output_path:
+        Destination file path for the resulting HTML document.
+
+    Returns
+    -------
+    :class:`~pathlib.Path`
+        Path to the generated file.
+    """
+
+    flows = list(flows)
+    if not flows:
+        raise ValueError("No flows provided for rendering")
+
+    labels: List[str] = []
+    styles = {}
+    for flow in flows:
+        for name, style in (
+            (flow.source, flow.source_style),
+            (flow.target, flow.target_style),
+        ):
+            if name not in styles:
+                styles[name] = style
+                labels.append(name)
+
+    label_to_idx = {label: i for i, label in enumerate(labels)}
+
+    node_colors = [styles[label].color for label in labels]
+    node_x = [styles[label].depth for label in labels]
+
+    link_source = [label_to_idx[flow.source] for flow in flows]
+    link_target = [label_to_idx[flow.target] for flow in flows]
+    link_value = [flow.value for flow in flows]
+    link_colors = [styles[flow.source].color for flow in flows]
+
+    sankey = go.Sankey(
+        node=dict(label=labels, color=node_colors, x=node_x, pad=15, thickness=20),
+        link=dict(source=link_source, target=link_target, value=link_value, color=link_colors),
+        arrangement="fixed",
+    )
+    fig = go.Figure(data=[sankey])
+
+    # Generate a responsive HTML snippet suitable for embedding in web pages
+    html = fig.to_html(full_html=False, include_plotlyjs="cdn", config={"responsive": True})
+    path = Path(output_path)
+    path.write_text(html, encoding="utf-8")
+    return path


### PR DESCRIPTION
## Summary
- add `visualisation.sankey_render` module that converts accounting flows into Plotly Sankey diagrams and writes a responsive HTML snippet
- document ribbon timeline design goals and comparisons with existing tools
- test that rendering produces an embeddable HTML file

## Testing
- `PYENV_VERSION=3.12.10 python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68987ab8e3888322923a822e3a70821f