### PR TITLE
Add NewsAPI integration to fetch daily articles

### DIFF
--- a/integrations/news_api.py
+++ b/integrations/news_api.py
@@ -1,0 +1,56 @@
+"""Retrieve news articles for a specific day using the NewsAPI service."""
+
+from datetime import date
+from typing import Dict, List, Union
+
+import requests
+
+BASE_URL = "https://newsapi.org/v2/everything"
+
+
+def search_news(
+    query: str,
+    day: Union[date, str],
+    api_key: str,
+    *,
+    page_size: int = 10,
+) -> List[Dict]:
+    """Return news articles matching *query* published on *day*.
+
+    Parameters
+    ----------
+    query:
+        Keywords to search for.
+    day:
+        Date of interest as :class:`datetime.date` or ISO formatted string.
+    api_key:
+        API key for the NewsAPI service.
+    page_size:
+        Number of results to fetch (1-100). Defaults to 10.
+
+    Returns
+    -------
+    list of dict
+        Article entries as returned by the API. If the request fails,
+        an empty list is returned.
+    """
+
+    day_str = day if isinstance(day, str) else day.isoformat()
+    params = {
+        "q": query,
+        "from": day_str,
+        "to": day_str,
+        "language": "en",
+        "sortBy": "relevancy",
+        "pageSize": page_size,
+        "apiKey": api_key,
+    }
+
+    try:
+        response = requests.get(BASE_URL, params=params, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException:
+        return []
+
+    data = response.json()
+    return data.get("articles", [])

--- a/tests/test_news_api.py
+++ b/tests/test_news_api.py
@@ -1,0 +1,49 @@
+from datetime import date
+import requests
+
+from integrations.news_api import BASE_URL, search_news
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no exception
+        return None
+
+    def json(self):
+        return self._data
+
+
+def test_search_news_success(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params=None, timeout=0):
+        captured["url"] = url
+        captured["params"] = params
+        return DummyResponse({"articles": [{"title": "headline"}]})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = search_news("keyword", date(2024, 5, 1), "KEY", page_size=5)
+
+    assert result == [{"title": "headline"}]
+    assert captured["url"] == BASE_URL
+    assert captured["params"]["from"] == "2024-05-01"
+    assert captured["params"]["to"] == "2024-05-01"
+    assert captured["params"]["q"] == "keyword"
+    assert captured["params"]["pageSize"] == 5
+    assert captured["params"]["apiKey"] == "KEY"
+    assert captured["params"]["language"] == "en"
+    assert captured["params"]["sortBy"] == "relevancy"
+
+
+def test_search_news_failure(monkeypatch):
+    def fake_get(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = search_news("anything", date(2024, 5, 1), "KEY")
+
+    assert result == []


### PR DESCRIPTION
## Summary
- add `search_news` helper for retrieving NewsAPI articles on a given day
- cover NewsAPI helper with unit tests and mock requests

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_news_api.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68989dfeffe88322927675d2f3faa0e9