### PR TITLE
Track contact frequency for timeline

### DIFF
--- a/Pelican/generate_content.py
+++ b/Pelican/generate_content.py
@@ -1,23 +1,28 @@
 import json
 import os
 import urllib.parse
+from datetime import datetime
+
+from contact_frequency_cache import ContactFrequencyCache
 from generate_html_timeline_item import generate_html_timeline_item
 from generate_html_dangling_audio import generate_html_dangling_audio
 from generate_html_dangling_transcripts import generate_html_dangling_transcripts
 
 
 # Load matches and dangling files
-with open('matches.json', 'r') as f:
+with open("matches.json", "r") as f:
     matches = json.load(f)
 
 print("Loaded matches:", matches)  # Debug print
 
-with open('dangling_audio.json', 'r') as f:
+cache = ContactFrequencyCache()
+
+with open("dangling_audio.json", "r") as f:
     dangling_audio = json.load(f)
 
 print("Loaded dangling audio:", dangling_audio)  # Debug print
 
-with open('dangling_transcripts.json', 'r') as f:
+with open("dangling_transcripts.json", "r") as f:
     dangling_transcripts = json.load(f)
 
 print("Loaded dangling transcripts:", dangling_transcripts)  # Debug print
@@ -52,6 +57,9 @@ for match in matches:
     platform = match[2]
     contact = match[3]
 
+    timestamp = datetime.fromtimestamp(os.path.getmtime(audio_file))
+    cache.record(contact, timestamp)
+
     # Create symbolic links
     audio_symlink = os.path.join(symlink_dir, os.path.basename(audio_file))
     transcript_symlink = os.path.join(symlink_dir, os.path.basename(transcript_file))
@@ -63,7 +71,9 @@ for match in matches:
 
     # URL-encode the paths for HTML
     encoded_audio_symlink = urllib.parse.quote(os.path.basename(audio_symlink))
-    encoded_transcript_symlink = urllib.parse.quote(os.path.basename(transcript_symlink))
+    encoded_transcript_symlink = urllib.parse.quote(
+        os.path.basename(transcript_symlink)
+    )
 
     html_content += generate_html_timeline_item(
         encoded_audio_symlink,
@@ -72,6 +82,12 @@ for match in matches:
         platform,
         contact,
     )
+
+daily_counts = cache.daily_counts()
+frequency_ranking = [
+    {"contact": c, "count": sum(days.values())} for c, days in daily_counts.items()
+]
+frequency_ranking.sort(key=lambda x: x["count"], reverse=True)
 
 html_content += """
             </div>
@@ -83,18 +99,22 @@ html_content += """
 html_content += generate_html_dangling_audio(dangling_audio, symlink_dir)
 html_content += generate_html_dangling_transcripts(dangling_transcripts, symlink_dir)
 
-html_content += """
+html_content += (
+    """
         </section>
     </main>
+    <script>window.contactFrequencies = """
+    + json.dumps(frequency_ranking)
+    + """;</script>
     <script src="scripts.js"></script>
     <script src="timeline3d.js"></script>
 </body>
 </html>
 """
+)
 
 # Write the HTML content to a file
 with open("content/timeline.html", "w") as f:
     f.write(html_content)
 
 print("HTML content generated successfully.")
-

--- a/contact_frequency_cache.py
+++ b/contact_frequency_cache.py
@@ -1,0 +1,27 @@
+from collections import defaultdict
+from datetime import datetime, date
+from typing import Dict
+
+
+class ContactFrequencyCache:
+    """Cache counting contact occurrences by day."""
+
+    def __init__(self) -> None:
+        self._data: Dict[str, Dict[date, int]] = defaultdict(lambda: defaultdict(int))
+
+    def record(self, contact: str, ts: datetime) -> None:
+        """Record a contact occurrence for the given timestamp."""
+        day = ts.date()
+        self._data[contact][day] += 1
+
+    def daily_counts(self) -> Dict[str, Dict[date, int]]:
+        """Return a mapping of contacts to their per-day counts."""
+        return {c: dict(days) for c, days in self._data.items()}
+
+    def frequency_ranking(self) -> list[tuple[str, int]]:
+        """Return contacts sorted by total frequency descending."""
+        totals = {c: sum(days.values()) for c, days in self._data.items()}
+        return sorted(totals.items(), key=lambda item: item[1], reverse=True)
+
+
+__all__ = ["ContactFrequencyCache"]


### PR DESCRIPTION
## Summary
- add `ContactFrequencyCache` to tally daily contact occurrences
- record contact timestamps while generating HTML and expose sorted frequencies to client scripts

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6898c8e120ac832282ee569ad976f740