### PR TITLE
feat: layer timeline items by contact frequency

### DIFF
--- a/Pelican/timeline3d.js
+++ b/Pelican/timeline3d.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const items = document.querySelectorAll('.timeline-item');
   const platformIndex = {};
-  const contactIndex = {};
+  const contactCounts = {};
 
   items.forEach(item => {
     const platform = item.dataset.platform || 'unknown';
@@ -10,34 +10,25 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!(platform in platformIndex)) {
       platformIndex[platform] = Object.keys(platformIndex).length;
     }
-    if (!(contact in contactIndex)) {
-      contactIndex[contact] = Object.keys(contactIndex).length;
-    }
+
+    contactCounts[contact] = (contactCounts[contact] || 0) + 1;
+  });
+
+  const sortedContacts = Object.entries(contactCounts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([contact]) => contact);
+
+  const contactIndex = {};
+  sortedContacts.forEach((contact, index) => {
+    contactIndex[contact] = index;
+  });
+
+  items.forEach(item => {
+    const platform = item.dataset.platform || 'unknown';
+    const contact = item.dataset.contact || 'unknown';
 
     const x = platformIndex[platform] * 200;
     const z = contactIndex[contact] * 200;
     item.style.transform = `translate3d(${x}px, 0px, ${z}px)`;
   });
 });
-=======
-(function() {
-    function initTimeline3D() {
-        var container = document.querySelector('.timeline-container');
-        if (!container) {
-            return;
-        }
-
-        container.classList.add('timeline-3d-container');
-
-        var items = container.querySelectorAll('.timeline-item');
-        var depthStep = 100;
-        var z = 0;
-
-        items.forEach(function(item) {
-            item.style.transform = 'translateZ(' + z + 'px)';
-            z -= depthStep;
-        });
-    }
-
-    window.initTimeline3D = initTimeline3D;
-})();


### PR DESCRIPTION
## Summary
- sort timeline item depth by contact frequency so popular contacts stay consistent
- remove stale timeline 3D IIFE block

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c8d47a0483229e178e1a7d58a594