### PR TITLE
Add frequency metadata to timeline items

### DIFF
--- a/Pelican/generate_content.py
+++ b/Pelican/generate_content.py
@@ -1,23 +1,26 @@
+"""Build the timeline HTML page."""
+
 import json
 import os
-import urllib.parse
+
 from generate_html_timeline_item import generate_html_timeline_item
 from generate_html_dangling_audio import generate_html_dangling_audio
 from generate_html_dangling_transcripts import generate_html_dangling_transcripts
+from transcript_frequency import calculate_noun_frequency
 
 
 # Load matches and dangling files
-with open('matches.json', 'r') as f:
+with open("matches.json", "r") as f:
     matches = json.load(f)
 
 print("Loaded matches:", matches)  # Debug print
 
-with open('dangling_audio.json', 'r') as f:
+with open("dangling_audio.json", "r") as f:
     dangling_audio = json.load(f)
 
 print("Loaded dangling audio:", dangling_audio)  # Debug print
 
-with open('dangling_transcripts.json', 'r') as f:
+with open("dangling_transcripts.json", "r") as f:
     dangling_transcripts = json.load(f)
 
 print("Loaded dangling transcripts:", dangling_transcripts)  # Debug print
@@ -61,16 +64,16 @@ for match in matches:
     if not os.path.exists(transcript_symlink):
         os.symlink(transcript_file, transcript_symlink)
 
-    # URL-encode the paths for HTML
-    encoded_audio_symlink = urllib.parse.quote(os.path.basename(audio_symlink))
-    encoded_transcript_symlink = urllib.parse.quote(os.path.basename(transcript_symlink))
+    # Determine a frequency metric using noun detection for the transcript
+    frequency = calculate_noun_frequency(transcript_file)
 
     html_content += generate_html_timeline_item(
-        encoded_audio_symlink,
-        encoded_transcript_symlink,
+        os.path.basename(audio_symlink),
+        os.path.basename(transcript_symlink),
         transcript_symlink,
         platform,
         contact,
+        frequency,
     )
 
 html_content += """
@@ -97,4 +100,3 @@ with open("content/timeline.html", "w") as f:
     f.write(html_content)
 
 print("HTML content generated successfully.")
-

--- a/Pelican/generate_html_timeline_item.py
+++ b/Pelican/generate_html_timeline_item.py
@@ -1,35 +1,62 @@
-import os
+"""Helpers for building timeline HTML blocks."""
+
+from __future__ import annotations
+
 import urllib.parse
-from read_file_with_fallback import read_file_with_fallback
+
+from .read_file_with_fallback import read_file_with_fallback
 
 
 def generate_html_timeline_item(
-    encoded_audio_symlink, encoded_transcript_symlink, transcript_symlink
+    audio_symlink: str,
+    transcript_symlink: str,
+    transcript_path: str,
+    platform: str,
+    contact: str,
+    frequency: int | float | None = None,
+) -> str:
+    """Return an HTML snippet for a single timeline item.
 
-def generate_html_timeline_item(
-    encoded_audio_symlink,
-    encoded_transcript_symlink,
-    transcript_symlink,
-    platform,
-    contact,
-):
-    transcript_content = read_file_with_fallback(transcript_symlink)
+    Parameters
+    ----------
+    audio_symlink:
+        Filename of the audio symlink relative to the ``symlinks`` directory.
+    transcript_symlink:
+        Filename of the transcript symlink relative to the ``symlinks`` directory.
+    transcript_path:
+        Path to the transcript file used for the ``pre`` tag contents.
+    platform:
+        Name of the platform the recording originated from.
+    contact:
+        Name of the contact associated with the recording.
+    frequency:
+        Optional frequency value to emit as a ``data-frequency`` attribute.
 
-    # Use urllib.parse.quote to ensure proper encoding
-    encoded_audio_symlink = urllib.parse.quote(encoded_audio_symlink)
-    encoded_transcript_symlink = urllib.parse.quote(encoded_transcript_symlink)
-
-    return f"""
-        <div class="timeline-item" role="listitem">
-
-        <div class="timeline-item" data-platform="{platform}" data-contact="{contact}">
-            <a href="#" class="label" data-audio="symlinks/{encoded_audio_symlink}" data-transcript="symlinks/{encoded_transcript_symlink}">{encoded_audio_symlink}</a>
-            <div class="audio-player" style="display: none;">
-                <audio controls>
-                    <source data-src="symlinks/{encoded_audio_symlink}" type="audio/mpeg">
-                </audio>
-                <pre>{transcript_content}</pre>
-                <div class="highlight-container"></div>
-            </div>
-        </div>
+    Returns
+    -------
+    str
+        A block of HTML representing the timeline item.
     """
+
+    transcript_content = read_file_with_fallback(transcript_path)
+
+    # Ensure proper URL encoding for use in HTML attributes
+    encoded_audio = urllib.parse.quote(audio_symlink)
+    encoded_transcript = urllib.parse.quote(transcript_symlink)
+
+    freq_attr = f' data-frequency="{frequency}"' if frequency is not None else ""
+
+    return (
+        f'<div class="timeline-item" role="listitem" '
+        f'data-platform="{platform}" data-contact="{contact}"{freq_attr}>'
+        f'<a href="#" class="label" data-audio="symlinks/{encoded_audio}" '
+        f'data-transcript="symlinks/{encoded_transcript}">{encoded_audio}</a>'
+        '<div class="audio-player" style="display: none;">'
+        "<audio controls>"
+        f'<source data-src="symlinks/{encoded_audio}" type="audio/mpeg">'
+        "</audio>"
+        f"<pre>{transcript_content}</pre>"
+        '<div class="highlight-container"></div>'
+        "</div>"
+        "</div>"
+    )

--- a/Pelican/transcript_frequency.py
+++ b/Pelican/transcript_frequency.py
@@ -1,0 +1,115 @@
+"""Utilities for estimating transcript word frequencies.
+
+This module provides a helper to compute a simple frequency metric for a
+transcript based on noun detection. When the ``nltk`` package is available,
+part-of-speech tagging is used to count noun tokens. Otherwise a fallback
+heuristic filters out common stop words and counts remaining tokens.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections import Counter
+from typing import Iterable
+
+try:  # pragma: no cover - exercised via functional tests
+    import nltk
+    from nltk import pos_tag
+    from nltk.tokenize import wordpunct_tokenize
+
+    _HAS_NLTK = True
+    try:  # ensure tagger is available
+        nltk.data.find("taggers/averaged_perceptron_tagger_eng")
+    except LookupError:  # download silently if missing
+        nltk.download("averaged_perceptron_tagger_eng", quiet=True)
+except Exception:  # pragma: no cover - if nltk is missing
+    _HAS_NLTK = False
+
+# Basic list of stop words used when NLTK is unavailable
+_STOPWORDS: set[str] = {
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "to",
+    "in",
+    "of",
+    "is",
+    "are",
+    "was",
+    "were",
+    "on",
+    "for",
+    "with",
+    "as",
+    "by",
+    "at",
+    "it",
+    "this",
+    "that",
+    "from",
+    "be",
+    "have",
+    "has",
+    "had",
+    "i",
+    "you",
+    "he",
+    "she",
+    "we",
+    "they",
+    "me",
+    "him",
+    "her",
+    "them",
+    "but",
+    "not",
+    "will",
+    "would",
+    "can",
+    "could",
+    "should",
+    "may",
+    "might",
+    "must",
+    "if",
+    "when",
+    "while",
+}
+
+
+def _extract_nouns(text: str) -> Iterable[str]:
+    """Return a list of noun-like tokens from ``text``."""
+    if _HAS_NLTK:
+        tokens = wordpunct_tokenize(text)
+        tagged = pos_tag(tokens)
+        return [word.lower() for word, tag in tagged if tag.startswith("NN")]
+    words = re.findall(r"\b[a-zA-Z]+\b", text)
+    return [w.lower() for w in words if w.lower() not in _STOPWORDS]
+
+
+def calculate_noun_frequency(path: str) -> int | None:
+    """Calculate a noun-based frequency metric for a transcript file.
+
+    Parameters
+    ----------
+    path:
+        Path to a transcript file. If the file does not exist, ``None`` is
+        returned.
+
+    Returns
+    -------
+    int | None
+        Number of noun tokens detected, or ``None`` if the file is missing.
+    """
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+    nouns = _extract_nouns(text)
+    return sum(Counter(nouns).values())
+
+
+__all__ = ["calculate_noun_frequency"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ piecash
 plotly
 
 networkx
+nltk

--- a/tests/test_generate_html_timeline_item.py
+++ b/tests/test_generate_html_timeline_item.py
@@ -1,0 +1,33 @@
+from Pelican.generate_html_timeline_item import generate_html_timeline_item
+
+
+def test_generate_html_timeline_item_without_frequency(tmp_path):
+    transcript = tmp_path / "sample.txt"
+    transcript.write_text("hello world")
+
+    html = generate_html_timeline_item(
+        "audio.mp3",
+        "transcript.txt",
+        str(transcript),
+        "phone",
+        "Alice",
+    )
+
+    assert "data-frequency" not in html
+    assert 'data-platform="phone"' in html
+
+
+def test_generate_html_timeline_item_with_frequency(tmp_path):
+    transcript = tmp_path / "sample.txt"
+    transcript.write_text("hello world")
+
+    html = generate_html_timeline_item(
+        "audio.mp3",
+        "transcript.txt",
+        str(transcript),
+        "phone",
+        "Alice",
+        frequency=5,
+    )
+
+    assert 'data-frequency="5"' in html

--- a/tests/test_transcript_frequency.py
+++ b/tests/test_transcript_frequency.py
@@ -1,0 +1,11 @@
+from Pelican.transcript_frequency import calculate_noun_frequency
+
+
+def test_calculate_noun_frequency_counts_nouns(tmp_path):
+    transcript = tmp_path / "sample.txt"
+    transcript.write_text("Alice met Bob in Wonderland. Alice saw the rabbit.")
+
+    freq = calculate_noun_frequency(str(transcript))
+
+    # Expected nouns: Alice, Bob, Wonderland, Alice, rabbit -> 5 occurrences
+    assert freq == 5


### PR DESCRIPTION
## Summary
- derive transcript frequency by counting detected nouns
- feed noun frequency into generated timeline items as metadata
- cover noun frequency logic with dedicated tests

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_generate_html_timeline_item.py tests/test_transcript_frequency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c8eb4c58832291a367e9d28004f4