### PR TITLE
Track contact frequency for timeline

### DIFF
--- a/contact_frequency_cache.py
+++ b/contact_frequency_cache.py
@@ -1,0 +1,28 @@
+"""Helpers for counting contact occurrences across days."""
+
+from collections import defaultdict
+from datetime import date, datetime
+
+
+class ContactFrequencyCache:
+    """Cache counting contact occurrences by day."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, dict[date, int]] = defaultdict(lambda: defaultdict(int))
+
+    def record(self, contact: str, ts: datetime) -> None:
+        """Record a contact occurrence for the given timestamp."""
+        day = ts.date()
+        self._data[contact][day] += 1
+
+    def daily_counts(self) -> dict[str, dict[date, int]]:
+        """Return a mapping of contacts to their per-day counts."""
+        return {c: dict(days) for c, days in self._data.items()}
+
+    def frequency_ranking(self) -> list[tuple[str, int]]:
+        """Return contacts sorted by total frequency descending."""
+        totals = {c: sum(days.values()) for c, days in self._data.items()}
+        return sorted(totals.items(), key=lambda item: item[1], reverse=True)
+
+
+__all__ = ["ContactFrequencyCache"]


### PR DESCRIPTION
## Summary
- add `ContactFrequencyCache` to tally daily contact occurrences
- record contact timestamps while generating HTML and expose sorted frequencies to client scripts
- streamline ranking usage and drop leftover debug prints

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c8e120ac832282ee569ad976f740