### PR TITLE
Add basic timeline spawn system

### DIFF
--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -1,0 +1,34 @@
+use bevy::prelude::*;
+
+#[derive(Component, Clone, Debug)]
+pub struct TimelineItem {
+    pub id: u64,
+    pub timestamp: f64,
+    pub medium: String,
+    pub participants: Vec<String>,
+    pub content: String,
+}
+
+const PIXELS_PER_SECOND: f32 = 10.0;
+
+pub fn time_to_y(base_time: f64, timestamp: f64) -> f32 {
+    ((timestamp - base_time) as f32) * PIXELS_PER_SECOND
+}
+
+pub fn spawn_timeline(mut commands: Commands, items: Res<Vec<TimelineItem>>) {
+    if items.is_empty() {
+        return;
+    }
+
+    let start_time = items[0].timestamp;
+    for item in items.iter() {
+        let y = time_to_y(start_time, item.timestamp);
+        commands
+            .spawn((
+                Transform::from_xyz(0.0, y, 0.0),
+                GlobalTransform::default(),
+                item.clone(),
+            ));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add TimelineItem component for storing timeline data
- map timestamps to screen positions with `time_to_y`
- spawn system to insert items with transform based on time

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899ad3be17883229a4b21b8c1f49cf6