### PR TITLE
Implement daily email drilldown and navigation controls

### DIFF
--- a/docs/3d_timeline.md
+++ b/docs/3d_timeline.md
@@ -6,6 +6,13 @@ The 3D timeline models how interactions move across platforms and contacts over 
 - **Y – Time**: The vertical axis tracks chronological sequence so trends and gaps become clear.
 - **Z – Contact**: The depth axis separates individual contacts, allowing focused review of each relationship.
 
+## Email Drilldown
+
+Selecting an email bubble collapses the timeline to a daily view that isolates
+only that day's messages. **Y:** maintains chronological order, **X:** becomes
+contacts, and **Z:** resets to a flat plane. Use up/down keys to step through
+emails and left/right keys to switch contacts.
+
 ## Rationale
 
 Prioritizing platforms on the X-axis keeps similar media aligned, while a vertical time axis communicates progression at a glance. Using depth for contacts allows simultaneous comparison of different relationships without losing temporal context.

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from timeline import emails_for_day, index_emails_by_contact, step_index
+
+
+def _sample_events():
+    return [
+        {
+            "time": datetime(2024, 5, 1, 9),
+            "source": "email",
+            "contact": "Alice",
+            "id": 1,
+        },
+        {
+            "time": datetime(2024, 5, 1, 10),
+            "source": "chat",
+            "contact": "Alice",
+            "id": 2,
+        },
+        {"time": datetime(2024, 5, 1, 8), "source": "email", "contact": "Bob", "id": 3},
+        {"time": datetime(2024, 5, 2, 9), "source": "email", "contact": "Bob", "id": 4},
+    ]
+
+
+def test_emails_for_day_filters_and_sorts():
+    events = _sample_events()
+    result = emails_for_day(events, datetime(2024, 5, 1))
+    assert [e["id"] for e in result] == [3, 1]
+
+
+def test_index_emails_by_contact_groups():
+    emails = emails_for_day(_sample_events(), datetime(2024, 5, 1))
+    index = index_emails_by_contact(emails)
+    assert [e["id"] for e in index["Alice"]] == [1]
+    assert [e["id"] for e in index["Bob"]] == [3]
+
+
+def test_step_index_wraps():
+    assert step_index(0, 1, 2) == 1
+    assert step_index(1, 1, 2) == 0
+    assert step_index(0, -1, 2) == 1

--- a/timeline.py
+++ b/timeline.py
@@ -4,7 +4,8 @@ Timelines merge events from multiple data sources (audio transcripts, web
 activity, etc.) into a single chronologically ordered stream.  Each event is a
 dictionary with at least a ``time`` field.
 """
-from datetime import datetime
+
+from datetime import datetime, timedelta
 from typing import Dict, Iterable, List, Mapping
 
 
@@ -43,3 +44,70 @@ def bucket_by_day(events: Iterable[Dict]) -> Dict[datetime, List[Dict]]:
         key = time.replace(hour=0, minute=0, second=0, microsecond=0)
         buckets.setdefault(key, []).append(event)
     return buckets
+
+
+def emails_for_day(events: Iterable[Dict], day: datetime) -> List[Dict]:
+    """Return email events for a single day sorted chronologically.
+
+    Parameters
+    ----------
+    events:
+        Iterable of event dictionaries that include ``time`` and ``source``
+        keys.
+    day:
+        Day to filter by. Time portion is ignored.
+
+    Returns
+    -------
+    list of dict
+        Email events from the specified day ordered by ``time``.
+    """
+
+    start = day.replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + timedelta(days=1)
+    daily: List[Dict] = []
+    for event in events:
+        time = event.get("time")
+        if event.get("source") != "email" or not isinstance(time, datetime):
+            continue
+        if start <= time < end:
+            daily.append(event)
+    daily.sort(key=lambda e: e.get("time", datetime.min))
+    return daily
+
+
+def index_emails_by_contact(emails: Iterable[Dict]) -> Dict[str, List[Dict]]:
+    """Group emails by contact, sorted chronologically within each contact."""
+
+    index: Dict[str, List[Dict]] = {}
+    for email in emails:
+        contact = email.get("contact")
+        if not contact:
+            continue
+        index.setdefault(contact, []).append(email)
+    for messages in index.values():
+        messages.sort(key=lambda e: e.get("time", datetime.min))
+    return index
+
+
+def step_index(current: int, step: int, total: int) -> int:
+    """Move within a list using wrap-around semantics.
+
+    Parameters
+    ----------
+    current:
+        Current position in the list.
+    step:
+        Positive or negative number of steps to move.
+    total:
+        Length of the list.
+
+    Returns
+    -------
+    int
+        New index after applying ``step``. Returns 0 if ``total`` is 0.
+    """
+
+    if total <= 0:
+        return 0
+    return (current + step) % total


### PR DESCRIPTION
## Summary
- support daily email drilldown with helpers to filter events by day, group by contact, and cycle through selections
- document how selecting an email bubble flattens Z while using Y for time and X for contacts
- add tests for daily filtering, contact grouping, and navigation wrap-around

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_timeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899ad5b6dd483229b675ea1fa18ca72