### PR TITLE
Replace Hugo site scaffolding with Zola site

### DIFF
--- a/Zola/config.toml
+++ b/Zola/config.toml
@@ -1,0 +1,4 @@
+base_url = "https://example.com"
+title = "Zola site"
+compile_sass = false
+build_search_index = false

--- a/Zola/content/_index.md
+++ b/Zola/content/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Home"
++++
+
+Welcome to the Zola site.

--- a/Zola/copy_assets.py
+++ b/Zola/copy_assets.py
@@ -1,0 +1,52 @@
+"""Copy audio and transcript files into the Zola static directory.
+
+This replaces the symlink generation used by the Pelican build.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SYMLINK_DIR = ROOT / "Zola" / "static" / "symlinks"
+
+
+def copy_assets(
+    matches_file: Path, dangling_audio_file: Path, dangling_transcripts_file: Path
+) -> None:
+    """Copy audio and transcript files into ``SYMLINK_DIR``.
+
+    Parameters
+    ----------
+    matches_file:
+        JSON file containing pairs of matched audio and transcript paths.
+    dangling_audio_file:
+        JSON file listing audio files without transcripts.
+    dangling_transcripts_file:
+        JSON file listing transcript files without audio.
+    """
+    SYMLINK_DIR.mkdir(parents=True, exist_ok=True)
+
+    matches = json.loads(matches_file.read_text())
+    dangling_audio = json.loads(dangling_audio_file.read_text())
+    dangling_transcripts = json.loads(dangling_transcripts_file.read_text())
+
+    for audio_file, transcript_file in matches:
+        shutil.copy2(audio_file, SYMLINK_DIR / Path(audio_file).name)
+        shutil.copy2(transcript_file, SYMLINK_DIR / Path(transcript_file).name)
+
+    for audio in dangling_audio:
+        shutil.copy2(audio, SYMLINK_DIR / Path(audio).name)
+
+    for transcript in dangling_transcripts:
+        shutil.copy2(transcript, SYMLINK_DIR / Path(transcript).name)
+
+
+if __name__ == "__main__":
+    copy_assets(
+        ROOT / "matches.json",
+        ROOT / "dangling_audio.json",
+        ROOT / "dangling_transcripts.json",
+    )

--- a/Zola/static/js/calendar.js
+++ b/Zola/static/js/calendar.js
@@ -1,0 +1,69 @@
+// Basic calendar colouring utility
+// intensities should be a mapping of ISO date strings to numbers 0..1
+// Example usage:
+//   applyCalendarColors(document.getElementById('calendar'), {'2024-05-06': 1, ...});
+
+function applyCalendarColors(container, intensities, baseColor = '0,0,128') {
+    Object.entries(intensities).forEach(([day, intensity]) => {
+        const cell = container.querySelector(`[data-day="${day}"]`);
+        if (!cell) return;
+        if (intensity === 0) {
+            cell.style.backgroundColor = 'white';
+        } else {
+            cell.style.backgroundColor = `rgba(${baseColor}, ${intensity})`;
+        }
+    });
+}
+
+// Render a single day's timeline as a vertical bar where each segment
+// represents a minute or second. `segments` can be either an array of counts
+// (for frequency mode) or a mapping of app name to arrays of counts (for app
+// mode). Pass `pxPerStep` to explicitly control pixel height of each step (e.g.
+// `1` for 1px per minute/second).
+function renderDayTimeline(
+    container,
+    segments,
+    { colorBy = 'frequency', colorMap = {}, baseColor = '0,0,128', pxPerStep = null } = {}
+) {
+    const stepCount = Array.isArray(segments)
+        ? segments.length
+        : (segments[Object.keys(segments)[0]] || []).length;
+    if (!stepCount) return;
+
+    const height = pxPerStep ? stepCount * pxPerStep : container.clientHeight;
+    const pixelsPerStep = height / stepCount;
+    container.innerHTML = '';
+    container.style.position = 'relative';
+    container.style.height = height + 'px';
+
+    if (colorBy === 'app') {
+        Object.entries(segments).forEach(([app, arr]) => {
+            arr.forEach((val, idx) => {
+                if (!val) return;
+                const div = document.createElement('div');
+                div.style.position = 'absolute';
+                div.style.top = (idx * pixelsPerStep) + 'px';
+                div.style.height = pixelsPerStep + 'px';
+                div.style.width = '100%';
+                div.style.backgroundColor = colorMap[app] || 'navy';
+                container.appendChild(div);
+            });
+        });
+    } else {
+        const maxVal = Math.max(...segments) || 1;
+        segments.forEach((val, idx) => {
+            if (!val) return;
+            const div = document.createElement('div');
+            div.style.position = 'absolute';
+            div.style.top = (idx * pixelsPerStep) + 'px';
+            div.style.height = pixelsPerStep + 'px';
+            div.style.width = '100%';
+            div.style.backgroundColor = `rgba(${baseColor}, ${val / maxVal})`;
+            container.appendChild(div);
+        });
+    }
+}
+
+// expose globally
+window.applyCalendarColors = applyCalendarColors;
+window.renderDayTimeline = renderDayTimeline;

--- a/Zola/static/js/custom.js
+++ b/Zola/static/js/custom.js
@@ -1,0 +1,12 @@
+// custom.js
+document.querySelectorAll('.recording').forEach(item => {
+    item.addEventListener('click', event => {
+        const audioSrc = event.target.dataset.audio;
+        const transcriptSrc = event.target.dataset.transcript;
+        // Load and play audio
+        // Load and display transcript
+    });
+});
+
+
+//probably ignore? 

--- a/Zola/static/js/js.js
+++ b/Zola/static/js/js.js
@@ -1,0 +1,11 @@
+<script>
+document.querySelectorAll('.recording').forEach(item => {
+    item.addEventListener('click', event => {
+        const audioSrc = event.target.dataset.audio;
+        const transcriptSrc = event.target.dataset.transcript;
+        // Load and play audio
+        // Load and display transcript
+    });
+});
+</script>
+ 

--- a/Zola/static/js/scripts.js
+++ b/Zola/static/js/scripts.js
@@ -1,0 +1,129 @@
+function supports3d() {
+    const css3d = !!window.CSS && CSS.supports('transform-style', 'preserve-3d');
+    let webgl = false;
+    try {
+        const canvas = document.createElement('canvas');
+        webgl = !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+    } catch (e) {
+        webgl = false;
+    }
+    return css3d || webgl;
+}
+
+function initTimeline3DIfSupported() {
+    const prefersReducedMotion = window.matchMedia(
+        '(prefers-reduced-motion: reduce)'
+    ).matches;
+    if (prefersReducedMotion || !supports3d()) {
+        return;
+    }
+
+    const script = document.createElement('script');
+    script.src = 'timeline3d.js';
+    script.onload = function() {
+        if (typeof window.initTimeline3D === 'function') {
+            window.initTimeline3D();
+        }
+    };
+    document.body.appendChild(script);
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+    const skipLink = document.querySelector('.skip-link');
+    if (skipLink) {
+        skipLink.addEventListener('click', function(event) {
+            const mainContent = document.getElementById('main-content');
+            if (mainContent) {
+                event.preventDefault();
+                mainContent.focus();
+            }
+        });
+    }
+
+    const timelineItems = document.querySelectorAll(".timeline-item");
+
+    timelineItems.forEach((item, index) => {
+        const label = item.querySelector(".label");
+        const audioPlayer = item.querySelector(".audio-player");
+        const audio = audioPlayer.querySelector("audio");
+        const source = audio.querySelector("source");
+        const transcript = audioPlayer.querySelector("pre");
+        const transcriptDisplay = audioPlayer.querySelector(".transcript-display");
+
+        const playerId = `player-${index}`;
+        audioPlayer.id = playerId;
+        label.setAttribute("role", "button");
+        label.setAttribute("aria-controls", playerId);
+        label.setAttribute("aria-expanded", "false");
+
+        label.addEventListener("click", function(event) {
+            event.preventDefault();
+            const isExpanded = label.getAttribute("aria-expanded") === "true";
+            if (isExpanded) {
+                audioPlayer.style.display = "none";
+                label.setAttribute("aria-expanded", "false");
+            } else {
+                audioPlayer.style.display = "block";
+                label.setAttribute("aria-expanded", "true");
+                if (!audio.src) {
+                    audio.src = source.getAttribute("data-src");
+                }
+            }
+        });
+
+        label.addEventListener("keydown", function(event) {
+            if (event.key === "ArrowRight") {
+                event.preventDefault();
+                const next = timelineItems[index + 1];
+                if (next) {
+                    next.querySelector(".label").focus();
+                }
+            } else if (event.key === "ArrowLeft") {
+                event.preventDefault();
+                const prev = timelineItems[index - 1];
+                if (prev) {
+                    prev.querySelector(".label").focus();
+                }
+            }
+        });
+
+        audio.addEventListener("timeupdate", function() {
+            const currentTime = audio.currentTime;
+            const lines = transcript.textContent.split('\n');
+            let highlighted = false;
+
+            transcript.innerHTML = lines.map(line => {
+                const timeMatch = line.match(/\d{2}:\d{2}:\d{2},\d{3}/g);
+                if (timeMatch) {
+                    const [start, end] = timeMatch.map(time => {
+                        const [hours, minutes, seconds] = time.split(':');
+                        return parseInt(hours) * 3600 + parseInt(minutes) * 60 + parseFloat(seconds.replace(',', '.'));
+                    });
+                    if (currentTime >= start && currentTime <= end && !highlighted) {
+                        highlighted = true;
+                        return `<span class="highlight">${line}</span>`;
+                    }
+                }
+                return line;
+            }).join('\n');
+
+            transcriptDisplay.innerHTML = lines.map(line => {
+                const timeMatch = line.match(/\d{2}:\d{2}:\d{2},\d{3}/g);
+                if (timeMatch) {
+                    const [start, end] = timeMatch.map(time => {
+                        const [hours, minutes, seconds] = time.split(':');
+                        return parseInt(hours) * 3600 + parseInt(minutes) * 60 + parseFloat(seconds.replace(',', '.'));
+                    });
+                    if (currentTime >= start && currentTime <= end && !highlighted) {
+                        highlighted = true;
+                        return `<div class="highlight">${line}</div>`;
+                    }
+                }
+                return line;
+            }).join('\n');
+        });
+    });
+
+    initTimeline3DIfSupported();
+});
+

--- a/Zola/static/js/timeline3d.js
+++ b/Zola/static/js/timeline3d.js
@@ -1,0 +1,34 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const items = document.querySelectorAll('.timeline-item');
+  const platformIndex = {};
+  const contactCounts = {};
+
+  items.forEach(item => {
+    const platform = item.dataset.platform || 'unknown';
+    const contact = item.dataset.contact || 'unknown';
+
+    if (!(platform in platformIndex)) {
+      platformIndex[platform] = Object.keys(platformIndex).length;
+    }
+
+    contactCounts[contact] = (contactCounts[contact] || 0) + 1;
+  });
+
+  const sortedContacts = Object.entries(contactCounts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([contact]) => contact);
+
+  const contactIndex = {};
+  sortedContacts.forEach((contact, index) => {
+    contactIndex[contact] = index;
+  });
+
+  items.forEach(item => {
+    const platform = item.dataset.platform || 'unknown';
+    const contact = item.dataset.contact || 'unknown';
+
+    const x = platformIndex[platform] * 200;
+    const z = contactIndex[contact] * 200;
+    item.style.transform = `translate3d(${x}px, 0px, ${z}px)`;
+  });
+});

--- a/Zola/static/symlinks/example.mp3
+++ b/Zola/static/symlinks/example.mp3
@@ -1,0 +1,1 @@
+example audio

--- a/Zola/static/symlinks/example.txt
+++ b/Zola/static/symlinks/example.txt
@@ -1,0 +1,1 @@
+example transcript

--- a/Zola/templates/base.html
+++ b/Zola/templates/base.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ config.title }}</title>
+  </head>
+  <body>
+    {% block content %}{% endblock content %}
+  </body>
+</html>

--- a/Zola/templates/index.html
+++ b/Zola/templates/index.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% import "partials/timeline_item.html" as timeline %}
+
+{% block content %}
+<div id="timeline" role="list">
+  {{ timeline::timeline_item(audio_symlink="example.mp3", transcript_symlink="example.txt", platform="example", contact="contact", frequency=1) }}
+</div>
+{% endblock content %}

--- a/Zola/templates/partials/timeline_item.html
+++ b/Zola/templates/partials/timeline_item.html
@@ -1,0 +1,15 @@
+{% macro timeline_item(audio_symlink, transcript_symlink, platform, contact, frequency) %}
+{% set transcript_content = load_data(path="static/symlinks/" ~ transcript_symlink, format="plain") %}
+{% set encoded_audio = audio_symlink | urlencode %}
+{% set encoded_transcript = transcript_symlink | urlencode %}
+<div class="timeline-item" role="listitem" data-platform="{{ platform }}" data-contact="{{ contact }}"{% if frequency %} data-frequency="{{ frequency }}"{% endif %}>
+    <a href="#" class="label" data-audio="symlinks/{{ encoded_audio }}" data-transcript="symlinks/{{ encoded_transcript }}">{{ encoded_audio }}</a>
+    <div class="audio-player" style="display: none;">
+        <audio controls>
+            <source data-src="symlinks/{{ encoded_audio }}" type="audio/mpeg">
+        </audio>
+        <pre>{{ transcript_content | safe }}</pre>
+        <div class="highlight-container"></div>
+    </div>
+</div>
+{% endmacro %}


### PR DESCRIPTION
## Summary
- replace prior Hugo site with Zola scaffolding
- render timeline items via Zola macro instead of Python helper
- copy audio and transcript assets into Zola's static directory for builds
- retain existing timeline JavaScript under Zola's static assets

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `zola -r Zola build`


------
https://chatgpt.com/codex/tasks/task_e_6899b99c92908322bb512a989137b793