### PR TITLE
Add tests for scanner and converter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Run tests before committing:
 
 ```
 PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q
+cargo test
 ```
 
 ## Pull Requests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "ffmpeg-cli"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,10 +183,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "io-uring"
@@ -188,6 +222,12 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "memchr"
@@ -211,7 +251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -223,6 +263,12 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pin-project-lite"
@@ -255,10 +301,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "slab"
@@ -288,6 +353,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +391,8 @@ version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "ffmpeg-cli",
+ "hound",
+ "tempfile",
 ]
 
 [[package]]
@@ -355,6 +435,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -428,3 +517,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 crossbeam-channel = "0.5"
 ffmpeg-cli = "0.1"
 
+[dev-dependencies]
+tempfile = "3"
+hound = "3"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod scanner;
 pub mod converter;
+
+#[cfg(test)]
+mod tests;

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -1,0 +1,14 @@
+use std::path::Path;
+use hound::{SampleFormat, WavSpec, WavWriter};
+
+pub fn write_dummy_wav(path: &Path) {
+    let spec = WavSpec {
+        channels: 1,
+        sample_rate: 8000,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(path, spec).unwrap();
+    writer.write_sample(0i16).unwrap();
+    writer.finalize().unwrap();
+}

--- a/src/tests/converter.rs
+++ b/src/tests/converter.rs
@@ -1,0 +1,15 @@
+use crate::converter::convert_file;
+use crate::tests::common::write_dummy_wav;
+use tempfile::tempdir;
+
+#[test]
+fn converts_wav_to_flac() {
+    let dir = tempdir().unwrap();
+    let wav_path = dir.path().join("sample.wav");
+    write_dummy_wav(&wav_path);
+
+    convert_file(wav_path.clone());
+
+    let flac_path = wav_path.with_extension("flac");
+    assert!(flac_path.exists());
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+mod scanner;
+mod converter;

--- a/src/tests/scanner.rs
+++ b/src/tests/scanner.rs
@@ -1,0 +1,25 @@
+use crate::scanner::start_scanner;
+use crate::tests::common::write_dummy_wav;
+use crossbeam_channel::unbounded;
+use std::time::Duration;
+use tempfile::tempdir;
+
+#[test]
+fn scanner_detects_wav_and_sends_to_queues() {
+    let dir = tempdir().unwrap();
+    let wav_path = dir.path().join("sample.wav");
+    write_dummy_wav(&wav_path);
+
+    let (tx_transcribe, rx_transcribe) = unbounded();
+    let (tx_convert, rx_convert) = unbounded();
+
+    let handle = start_scanner(vec![dir.path().to_path_buf()], tx_transcribe, tx_convert);
+
+    let transcribe_msg = rx_transcribe.recv_timeout(Duration::from_secs(2)).unwrap();
+    let convert_msg = rx_convert.recv_timeout(Duration::from_secs(2)).unwrap();
+
+    assert_eq!(transcribe_msg, wav_path);
+    assert_eq!(convert_msg, wav_path);
+
+    drop(handle);
+}


### PR DESCRIPTION
## Summary
- add Rust unit tests for directory scanning and WAV-to-FLAC conversion
- run `cargo test` in project CI instructions

## Testing
- `cargo test`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899bbf7ede08322a2c5edddb8fd2c0a