### PR TITLE
Load recording folders from database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +63,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +91,18 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "ffmpeg-cli"
@@ -173,6 +212,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +246,17 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "memchr"
@@ -225,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +310,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "proc-macro2"
@@ -255,16 +336,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -313,6 +420,7 @@ version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "ffmpeg-cli",
+ "rusqlite",
 ]
 
 [[package]]
@@ -349,6 +457,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -428,3 +548,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 crossbeam-channel = "0.5"
 ffmpeg-cli = "0.1"
+rusqlite = { version = "0.29", features = ["bundled"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,9 @@ fn main() {
     let mut args = env::args().skip(1);
     match args.next().as_deref() {
         Some("scan") => {
-            let dirs: Vec<PathBuf> = args.map(PathBuf::from).collect();
             let (tx_transcribe, _rx_t) = unbounded();
             let (tx_convert, rx_convert) = unbounded();
-            let scanner_handle = scanner::start_scanner(dirs, tx_transcribe, tx_convert);
+            let scanner_handle = scanner::start_scanner(tx_transcribe, tx_convert);
             let _converter_handle = converter::start_converter(rx_convert);
             let _ = scanner_handle.join();
         }
@@ -20,7 +19,7 @@ fn main() {
             }
         }
         _ => {
-            eprintln!("Usage: tircorder-rs <scan <dirs...>|convert <files...>>");
+            eprintln!("Usage: tircorder-rs <scan|convert <files...>>");
         }
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,75 +1,189 @@
 use crossbeam_channel::Sender;
-use std::collections::HashSet;
+use rusqlite::{params, Connection};
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::PathBuf;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
 const AUDIO_EXTENSIONS: &[&str] = &["wav", "flac", "mp3", "ogg", "amr"];
 const TRANSCRIPT_EXTENSIONS: &[&str] = &["srt", "txt", "vtt", "json", "tsv"];
 
-/// Starts a background thread that scans `directories` for new audio or transcript files.
+struct RateLimiter {
+    counter: u32,
+    max_interval: Duration,
+}
+
+impl RateLimiter {
+    fn new(max_secs: u64) -> Self {
+        Self {
+            counter: 0,
+            max_interval: Duration::from_secs(max_secs),
+        }
+    }
+
+    fn increment(&mut self) {
+        self.counter += 1;
+    }
+
+    fn reset(&mut self) {
+        self.counter = 0;
+    }
+
+    fn sleep(&self) {
+        let secs = 2u64.pow(self.counter).min(self.max_interval.as_secs());
+        thread::sleep(Duration::from_secs(secs));
+    }
+}
+
+/// Starts a background thread that scans recordings folders from `state.db` for new files.
 /// New WAV files are sent to `tx_convert` if no FLAC exists. Audio files without
 /// accompanying transcripts are sent to `tx_transcribe`.
 pub fn start_scanner(
-    directories: Vec<PathBuf>,
     tx_transcribe: Sender<PathBuf>,
     tx_convert: Sender<PathBuf>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
+        let conn = Connection::open("state.db").expect("failed to open database");
+        let directories = {
+            let mut stmt = conn
+                .prepare("SELECT id, folder_path, COALESCE(ignore_transcribing, 0), COALESCE(ignore_converting, 0) FROM recordings_folders")
+                .expect("failed to prepare statement");
+            stmt
+                .query_map([], |row| {
+                    let id: i64 = row.get(0)?;
+                    let path: String = row.get(1)?;
+                    let ignore_t: i64 = row.get(2)?;
+                    let ignore_c: i64 = row.get(3)?;
+                    Ok((id, PathBuf::from(path), ignore_t != 0, ignore_c != 0))
+                })
+                .expect("query failed")
+                .filter_map(Result::ok)
+                .collect::<Vec<_>>()
+        };
+
         let mut known_files: HashSet<PathBuf> = HashSet::new();
+        let mut rate_limiter = RateLimiter::new(60);
 
         loop {
-            let mut current_files = HashSet::new();
-
-            for dir in &directories {
+            let mut current_files: HashMap<PathBuf, (i64, bool, bool)> = HashMap::new();
+            for (folder_id, dir, ignore_t, ignore_c) in &directories {
                 if let Ok(entries) = fs::read_dir(dir) {
                     for entry in entries.flatten() {
                         let path = entry.path();
                         if let Some(ext) = path.extension().and_then(OsStr::to_str) {
-                            if AUDIO_EXTENSIONS.contains(&ext)
-                                || TRANSCRIPT_EXTENSIONS.contains(&ext)
-                            {
-                                current_files.insert(path);
+                            if AUDIO_EXTENSIONS.contains(&ext) || TRANSCRIPT_EXTENSIONS.contains(&ext) {
+                                current_files.insert(path, (*folder_id, *ignore_t, *ignore_c));
                             }
                         }
                     }
                 }
             }
 
-            let new_files: Vec<_> = current_files.difference(&known_files).cloned().collect();
+            let current_paths: HashSet<PathBuf> = current_files.keys().cloned().collect();
+            let new_files: Vec<PathBuf> = current_paths
+                .difference(&known_files)
+                .cloned()
+                .collect();
+
+            println!("New files found: {}", new_files.len());
+            if new_files.is_empty() {
+                rate_limiter.increment();
+                rate_limiter.sleep();
+            } else {
+                rate_limiter.reset();
+            }
+
             for file in &new_files {
-                if let Some(ext) = file.extension().and_then(OsStr::to_str) {
-                    if AUDIO_EXTENSIONS.contains(&ext) {
-                        let mut transcript_exists = false;
-                        if let Some(stem) = file.file_stem().and_then(OsStr::to_str) {
-                            if let Some(parent) = file.parent() {
-                                for t_ext in TRANSCRIPT_EXTENSIONS {
-                                    let candidate = parent.join(format!("{}.{}", stem, t_ext));
-                                    if candidate.exists() {
-                                        transcript_exists = true;
-                                        break;
+                if let Some((folder_id, ignore_t, ignore_c)) = current_files.get(file) {
+                    if let Some(ext) = file.extension().and_then(OsStr::to_str) {
+                        let ext_lower = ext.to_lowercase();
+                        let basename = file.file_name().and_then(OsStr::to_str).unwrap_or("");
+
+                        conn.execute(
+                            "INSERT OR IGNORE INTO known_files (file_name, folder_id, extension) VALUES (?1, ?2, ?3)",
+                            params![basename, folder_id, format!(".{}", ext_lower)],
+                        )
+                        .ok();
+                        let known_file_id: i64 = conn
+                            .query_row(
+                                "SELECT id FROM known_files WHERE file_name = ?1 AND folder_id = ?2",
+                                params![basename, folder_id],
+                                |row| row.get(0),
+                            )
+                            .unwrap_or(0);
+
+                        let unix_ts = fs::metadata(file)
+                            .and_then(|m| m.modified())
+                            .ok()
+                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                            .map(|d| d.as_secs() as i64)
+                            .unwrap_or(0);
+
+                        if AUDIO_EXTENSIONS.contains(&ext_lower.as_str()) {
+                            let mut transcript_exists = false;
+                            if let Some(stem) = file.file_stem().and_then(OsStr::to_str) {
+                                if let Some(parent) = file.parent() {
+                                    for t_ext in TRANSCRIPT_EXTENSIONS {
+                                        let candidate = parent.join(format!("{}.{}", stem, t_ext));
+                                        if candidate.exists() {
+                                            transcript_exists = true;
+                                            break;
+                                        }
                                     }
                                 }
                             }
-                        }
-                        if !transcript_exists {
-                            let _ = tx_transcribe.send(file.clone());
-                        }
-                        if ext == "wav" {
-                            let flac = file.with_extension("flac");
-                            if !flac.exists() {
-                                let _ = tx_convert.send(file.clone());
+                            conn.execute(
+                                "INSERT OR IGNORE INTO audio_files (known_file_id, unix_timestamp) VALUES (?1, ?2)",
+                                params![known_file_id, unix_ts],
+                            )
+                            .ok();
+                            if transcript_exists {
+                                println!(
+                                    "Skipping transcription for {}: transcript exists",
+                                    file.display()
+                                );
+                            } else if !ignore_t {
+                                let _ = tx_transcribe.send(file.clone());
+                                println!("Queued {} for transcription", file.display());
+                            } else {
+                                println!(
+                                    "Skipping transcription for {}: flagged to ignore",
+                                    file.display()
+                                );
                             }
+                            if ext_lower == "wav" {
+                                let flac = file.with_extension("flac");
+                                if flac.exists() {
+                                    println!(
+                                        "Skipping conversion for {}: FLAC exists",
+                                        file.display()
+                                    );
+                                } else if !ignore_c {
+                                    let _ = tx_convert.send(file.clone());
+                                    println!("Queued {} for conversion", file.display());
+                                } else {
+                                    println!(
+                                        "Skipping conversion for {}: flagged to ignore",
+                                        file.display()
+                                    );
+                                }
+                            }
+                        } else if TRANSCRIPT_EXTENSIONS.contains(&ext_lower.as_str()) {
+                            conn.execute(
+                                "INSERT OR IGNORE INTO transcript_files (known_file_id, unix_timestamp) VALUES (?1, ?2)",
+                                params![known_file_id, unix_ts],
+                            )
+                            .ok();
+                            println!("Registered transcript {}", file.display());
                         }
                     }
                 }
             }
 
-            known_files.extend(current_files.into_iter());
-
-            thread::sleep(Duration::from_secs(5));
+            known_files.clear();
+            known_files.extend(current_paths.into_iter());
         }
     })
 }


### PR DESCRIPTION
## Summary
- load scanner directories from `state.db`
- add rate limiter and metadata logging to Rust scanner
- invoke scanner without directory arguments via CLI

## Testing
- `cargo test -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6899bbeb988083229fd2fa44a580531a