### PR TITLE
Add CI workflow for Python and Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+        rust-toolchain: ['stable']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run Black
+        run: black --check .
+
+      - name: Run pytest
+        run: PYTHONPATH=. pytest -q
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust-toolchain }}
+          override: true
+
+      - name: Run cargo test
+        run: cargo test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Python checks and Rust tests

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test` *(fails: tests::converter::converts_wav_to_flac)*

------
https://chatgpt.com/codex/tasks/task_e_689c70c9f75c8322b4902cc909b48cfb