### PR TITLE
Add tests for timeline merging and bucketing

### DIFF
--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,6 +1,12 @@
 from datetime import datetime
 
-from timeline import emails_for_day, index_emails_by_contact, step_index
+from timeline import (
+    bucket_by_day,
+    emails_for_day,
+    index_emails_by_contact,
+    merge_event_streams,
+    step_index,
+)
 
 
 def _sample_events():
@@ -39,3 +45,31 @@ def test_step_index_wraps():
     assert step_index(0, 1, 2) == 1
     assert step_index(1, 1, 2) == 0
     assert step_index(0, -1, 2) == 1
+
+
+def test_merge_event_streams_sorts_and_tags():
+    streams = {
+        "a": [
+            {"time": datetime(2024, 5, 1, 12), "id": 1},
+            {"time": datetime(2024, 5, 1, 10), "id": 2},
+        ],
+        "b": [{"time": datetime(2024, 5, 1, 11), "id": 3}],
+    }
+    result = merge_event_streams(streams)
+    assert [e["id"] for e in result] == [2, 3, 1]
+    assert [e["source"] for e in result] == ["a", "b", "a"]
+
+
+def test_bucket_by_day_groups_and_skips_invalid():
+    events = [
+        {"time": datetime(2024, 5, 1, 9), "id": 1},
+        {"time": datetime(2024, 5, 1, 10), "id": 2},
+        {"time": datetime(2024, 5, 2, 11), "id": 3},
+        {"time": "not a datetime", "id": 4},
+    ]
+    buckets = bucket_by_day(events)
+    day_one = datetime(2024, 5, 1)
+    day_two = datetime(2024, 5, 2)
+    assert sorted(e["id"] for e in buckets[day_one]) == [1, 2]
+    assert [e["id"] for e in buckets[day_two]] == [3]
+    assert 4 not in [e["id"] for bucket in buckets.values() for e in bucket]


### PR DESCRIPTION
## Summary
- add deterministic checks for `merge_event_streams` sorting and source tagging
- test `bucket_by_day` grouping and ignoring invalid timestamps

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_timeline.py -q`
- `cargo test` *(fails: Failed to convert "/tmp/.tmpoHzIdu/sample.wav": No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c70d3c6f483228d8247aefa5f6aee