### PR TITLE
Add edge case tests for step_index

### DIFF
--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -39,3 +39,5 @@ def test_step_index_wraps():
     assert step_index(0, 1, 2) == 1
     assert step_index(1, 1, 2) == 0
     assert step_index(0, -1, 2) == 1
+    assert step_index(3, 1, 0) == 0
+    assert step_index(0, 2, -5) == 0


### PR DESCRIPTION
## Summary
- add step_index tests for zero and negative lengths to ensure function returns 0

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_timeline.py -q`
- `cargo test` *(fails: Failed to convert "/tmp/.tmpDFYMTe/sample.wav": No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c70dfeb08832298e7be561b59a924