### PR TITLE
Add test for empty word cloud

### DIFF
--- a/tests/test_wordcloud_utils.py
+++ b/tests/test_wordcloud_utils.py
@@ -25,3 +25,12 @@ def test_wordcloud_generation_and_retrieval(tmp_path):
     assert cur.fetchone()[0] == 1
     cache2.close()
 
+
+def test_empty_text_wordcloud(tmp_path):
+    db_path = tmp_path / "wc.sqlite"
+    cache = WordCloudCache(db_path=str(db_path))
+
+    summary = generate_wordcloud("", cache)
+    assert summary.word_counts == {}
+    assert summary.wordcloud_html == '<div class="wordcloud"></div>'
+    cache.close()


### PR DESCRIPTION
## Summary
- test: ensure empty text produces empty wordcloud and HTML stub

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_wordcloud_utils.py -q`
- `cargo test` *(fails: Failed to convert "sample.wav": No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c70f2baa8832283744fb8085b7374