### PR TITLE
feat: add visualiser interface

### DIFF
--- a/docs/visualiser_interface.md
+++ b/docs/visualiser_interface.md
@@ -1,0 +1,22 @@
+# Visualiser Interface
+
+Visualisers convert Python data structures into front-end output. The
+`Visualiser.visualise(data)` method receives JSON serialisable data such as
+nested `dict`, `list`, `int`, `float` and `str` values. Example payload:
+
+```json
+{
+  "nodes": [{"id": 1, "label": "start"}],
+  "edges": [[1, 2]]
+}
+```
+
+## Bevy visualiser
+
+`BevyVisualiser` serialises the payload to JSON and forwards it to a Bevy
+application. The transport layer is left as a placeholder for now.
+
+## Extending
+
+To add another visualiser, subclass `Visualiser` and implement
+`visualise(data)` with the desired output logic.

--- a/tircorder/interfaces/__init__.py
+++ b/tircorder/interfaces/__init__.py
@@ -1,0 +1,1 @@
+"""Visualisation interfaces."""

--- a/tircorder/interfaces/visualiser.py
+++ b/tircorder/interfaces/visualiser.py
@@ -1,0 +1,33 @@
+"""Abstract visualiser interface and Bevy implementation."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+import json
+
+
+class Visualiser(ABC):
+    """Base class for visualisers."""
+
+    @abstractmethod
+    def visualise(self, data: Any) -> None:
+        """Render *data* to a front-end.
+
+        Parameters
+        ----------
+        data:
+            JSON serialisable structure describing the render.
+        """
+
+
+class BevyVisualiser(Visualiser):
+    """Forward JSON data to a Bevy front-end."""
+
+    def visualise(self, data: Any) -> None:  # noqa: D401
+        message = json.dumps(data)
+        self.send_to_bevy(message)
+
+    def send_to_bevy(self, message: str) -> None:
+        """Placeholder for communication with Bevy."""
+        raise NotImplementedError("Implement Bevy communication")


### PR DESCRIPTION
## Summary
- add abstract `Visualiser` with Bevy placeholder
- document JSON format for visualisers and extension guidance

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test` *(fails: Failed to convert sample.wav: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d8d5e149c8322af320e067c09a16f