### PR TITLE
Add story exporter interface and JSON exporter with test

### DIFF
--- a/tests/test_story_exporter.py
+++ b/tests/test_story_exporter.py
@@ -1,0 +1,31 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tircorder"
+    / "interfaces"
+    / "story_exporter.py"
+)
+
+spec = importlib.util.spec_from_file_location("story_exporter", MODULE_PATH)
+story_exporter = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = story_exporter
+spec.loader.exec_module(story_exporter)
+JSONStoryExporter = story_exporter.JSONStoryExporter
+
+
+def test_json_story_exporter_round_trip(tmp_path: Path) -> None:
+    events = [{"id": 1, "text": "hello"}, {"id": 2, "text": "world"}]
+    exporter = JSONStoryExporter(events)
+
+    output = tmp_path / "events.json"
+    exporter.export_to_file(output)
+
+    with open(output, "r", encoding="utf-8") as fh:
+        loaded = json.load(fh)
+
+    assert loaded == events
+    assert exporter.export_stories() == events

--- a/tircorder/interfaces/__init__.py
+++ b/tircorder/interfaces/__init__.py
@@ -1,0 +1,5 @@
+"""Interfaces for exporting story events."""
+
+from .story_exporter import JSONStoryExporter, StoryExporter
+
+__all__ = ["StoryExporter", "JSONStoryExporter"]

--- a/tircorder/interfaces/story_exporter.py
+++ b/tircorder/interfaces/story_exporter.py
@@ -1,0 +1,36 @@
+"""Tools for exporting stories to various formats."""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+class StoryExporter(ABC):
+    """Abstract base class for exporting story events."""
+
+    @abstractmethod
+    def export_stories(self) -> List[Dict[str, Any]]:
+        """Return a list of story events."""
+
+    @abstractmethod
+    def export_to_file(self, filepath: str) -> None:
+        """Export the stories to *filepath*."""
+
+
+class JSONStoryExporter(StoryExporter):
+    """Serialise story events to a JSON file."""
+
+    def __init__(self, events: List[Dict[str, Any]]):
+        """Initialise the exporter with *events*."""
+        self.events = events
+
+    def export_stories(self) -> List[Dict[str, Any]]:
+        """Return the stored events."""
+        return self.events
+
+    def export_to_file(self, filepath: str) -> None:
+        """Write events as UTF-8 encoded JSON to *filepath*."""
+        with open(filepath, "w", encoding="utf-8") as fh:
+            json.dump(self.export_stories(), fh, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- add `StoryExporter` abstract base class
- implement `JSONStoryExporter` to write events to UTF-8 JSON
- test JSON exporter round-trip

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_story_exporter.py tests/test_calendar_utils.py -q`
- `cargo test` *(fails: Failed to convert "/tmp/.tmphgCBo3/sample.wav": No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d8d596420832281b91f9c2f101dfa