### PR TITLE
Add HTTP rule check client

### DIFF
--- a/tests/test_rule_check_client.py
+++ b/tests/test_rule_check_client.py
@@ -1,0 +1,39 @@
+import importlib.util
+import requests
+
+spec = importlib.util.spec_from_file_location(
+    "rule_check_client", "tircorder/interfaces/rule_check_client.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+HTTPRuleCheckClient = module.HTTPRuleCheckClient
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):  # pragma: no cover - no error expected
+        return None
+
+    def json(self):
+        return self._data
+
+
+def test_http_rule_check_client(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, timeout=0):
+        captured["url"] = url
+        captured["json"] = json
+        return DummyResponse({"compliant": True})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    client = HTTPRuleCheckClient("http://api")
+    event = {"id": 1}
+    result = client.check_event_with_sensiblaw(event)
+
+    assert result is True
+    assert captured["url"] == "http://api/rules/check"
+    assert captured["json"] == {"event": event}

--- a/tircorder/interfaces/__init__.py
+++ b/tircorder/interfaces/__init__.py
@@ -1,0 +1,5 @@
+"""Interface implementations for rule checking."""
+
+from .rule_check_client import RuleCheckClient, HTTPRuleCheckClient
+
+__all__ = ["RuleCheckClient", "HTTPRuleCheckClient"]

--- a/tircorder/interfaces/rule_check_client.py
+++ b/tircorder/interfaces/rule_check_client.py
@@ -1,0 +1,35 @@
+"""Clients for checking event compliance via Sensiblaw."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+import requests
+
+
+class RuleCheckClient(ABC):
+    """Abstract client for verifying events with Sensiblaw."""
+
+    @abstractmethod
+    def check_event_with_sensiblaw(self, event: Dict[str, Any]) -> bool:
+        """Return whether ``event`` is compliant according to Sensiblaw."""
+
+
+class HTTPRuleCheckClient(RuleCheckClient):
+    """HTTP implementation of :class:`RuleCheckClient`."""
+
+    def __init__(self, base_url: str, timeout: float = 5.0) -> None:
+        """Initialize client with API ``base_url`` and request ``timeout``."""
+
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def check_event_with_sensiblaw(self, event: Dict[str, Any]) -> bool:
+        """POST ``event`` to the Sensiblaw API and return compliance result."""
+
+        url = f"{self.base_url}/rules/check"
+        response = requests.post(url, json={"event": event}, timeout=self.timeout)
+        response.raise_for_status()
+        data = response.json()
+        return bool(data.get("compliant"))


### PR DESCRIPTION
## Summary
- add abstract RuleCheckClient and HTTPRuleCheckClient
- cover HTTP rule check client with tests

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_rule_check_client.py tests/test_calendar_utils.py -q`
- `cargo test` *(fails: Failed to convert "/tmp/.tmpz32d82/sample.wav": No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d8d5aec00832294f082667ee1e840