### PR TITLE
Add configuration management interface

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "tircorder.interfaces.config",
+    Path(__file__).resolve().parent.parent / "tircorder" / "interfaces" / "config.py",
+)
+config_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(config_module)
+TircorderConfig = config_module.TircorderConfig
+
+
+def test_set_and_get_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("TIRCORDER_CONFIG_PATH", str(config_path))
+
+    data = {
+        "api_base_url": "https://api.example.com",
+        "export_format": "json",
+        "output_path": str(tmp_path / "out"),
+    }
+    TircorderConfig.set_config(data)
+    assert config_path.exists()
+
+    loaded = TircorderConfig.get_config()
+    assert loaded == data
+
+
+def test_get_config_missing_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setenv("TIRCORDER_CONFIG_PATH", str(config_path))
+
+    assert TircorderConfig.get_config() == {}

--- a/tircorder/interfaces/__init__.py
+++ b/tircorder/interfaces/__init__.py
@@ -1,0 +1,3 @@
+"""Interface modules for Tircorder."""
+
+__all__ = []

--- a/tircorder/interfaces/config.py
+++ b/tircorder/interfaces/config.py
@@ -1,0 +1,41 @@
+"""Configuration management for Tircorder interfaces."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+
+class TircorderConfig:
+    """Manage persistence of Tircorder settings in a JSON file."""
+
+    CONFIG_ENV_VAR = "TIRCORDER_CONFIG_PATH"
+    DEFAULT_FILENAME = ".tircorder_config.json"
+
+    @classmethod
+    def _get_config_path(cls) -> Path:
+        """Return the path to the configuration file."""
+        env_path = os.environ.get(cls.CONFIG_ENV_VAR)
+        return Path(env_path) if env_path else Path.home() / cls.DEFAULT_FILENAME
+
+    @classmethod
+    def get_config(cls) -> Dict[str, Any]:
+        """Retrieve configuration from disk.
+
+        Returns an empty dictionary if the configuration file does not exist.
+        """
+        path = cls._get_config_path()
+        if not path.exists():
+            return {}
+        with path.open("r", encoding="utf-8") as config_file:
+            return json.load(config_file)
+
+    @classmethod
+    def set_config(cls, config: Dict[str, Any]) -> None:
+        """Persist the provided configuration dictionary to disk."""
+        path = cls._get_config_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as config_file:
+            json.dump(config, config_file, indent=2, sort_keys=True)


### PR DESCRIPTION
## Summary
- add `TircorderConfig` for reading and writing JSON configuration
- allow custom config path via `TIRCORDER_CONFIG_PATH`
- test persistence and retrieval of configuration values

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_config.py tests/test_calendar_utils.py -q`
- `cargo test` *(fails: Failed to convert "/tmp/.tmpVI6NMq/sample.wav": No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d8d671b48832281e89a648b6788a1