### PR TITLE
Add configuration utilities with persistent storage

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,43 @@
+"""Tests for TircorderConfig persistence utilities."""
+
+import json
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent / "tircorder" / "interfaces" / "config.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "tircorder.interfaces.config", MODULE_PATH
+)
+config_module = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(config_module)
+TircorderConfig = config_module.TircorderConfig
+
+
+def test_set_and_get_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configuration values should persist to disk and be retrievable."""
+    path = tmp_path / "config.json"
+    monkeypatch.setenv("TIRCORDER_CONFIG_PATH", str(path))
+    data = {
+        "api_base_url": "https://api.example.com",
+        "export_format": "json",
+        "output_path": "/tmp/output",
+    }
+    TircorderConfig.set_config(data)
+    assert path.exists()
+    with path.open("r", encoding="utf-8") as handle:
+        assert json.load(handle) == data
+    assert TircorderConfig.get_config() == data
+
+
+def test_get_config_returns_empty_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing config file should return an empty dictionary."""
+    path = tmp_path / "missing.json"
+    monkeypatch.setenv("TIRCORDER_CONFIG_PATH", str(path))
+    assert TircorderConfig.get_config() == {}

--- a/tircorder/interfaces/__init__.py
+++ b/tircorder/interfaces/__init__.py
@@ -1,0 +1,5 @@
+"""Interfaces package for tircorder."""
+
+from .config import TircorderConfig
+
+__all__ = ["TircorderConfig"]

--- a/tircorder/interfaces/config.py
+++ b/tircorder/interfaces/config.py
@@ -1,0 +1,55 @@
+"""Configuration utilities for tircorder."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+CONFIG_ENV_VAR = "TIRCORDER_CONFIG_PATH"
+DEFAULT_CONFIG_PATH = Path.home() / ".tircorder" / "config.json"
+
+
+class TircorderConfig:
+    """Manage persistence of tircorder settings.
+
+    Configuration values are stored in a JSON file whose path can be
+    overridden by setting the ``TIRCORDER_CONFIG_PATH`` environment variable.
+    When not set, the configuration is stored at ``~/.tircorder/config.json``.
+    """
+
+    @staticmethod
+    def _get_config_path() -> Path:
+        """Return the path to the configuration file, creating parent dirs."""
+        path = os.getenv(CONFIG_ENV_VAR)
+        config_path = Path(path).expanduser() if path else DEFAULT_CONFIG_PATH
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        return config_path
+
+    @classmethod
+    def get_config(cls) -> Dict[str, Any]:
+        """Load and return stored configuration values.
+
+        Returns:
+            A dictionary of configuration values. If the configuration file
+            does not exist, an empty dictionary is returned.
+        """
+
+        config_path = cls._get_config_path()
+        if not config_path.exists():
+            return {}
+        with config_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    @classmethod
+    def set_config(cls, config: Dict[str, Any]) -> None:
+        """Persist configuration values to disk.
+
+        Args:
+            config: Mapping of configuration keys to values.
+        """
+
+        config_path = cls._get_config_path()
+        with config_path.open("w", encoding="utf-8") as handle:
+            json.dump(config, handle, indent=2, sort_keys=True)


### PR DESCRIPTION
## Summary
- add `TircorderConfig` for reading and writing JSON configuration files
- allow configurable path via `TIRCORDER_CONFIG_PATH`
- cover configuration persistence with unit tests

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_config.py -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a7f29194e8832295ba40a8d74be9f0