### PR TITLE
Fix calendar utils test imports

### DIFF
--- a/tests/test_calendar_utils.py
+++ b/tests/test_calendar_utils.py
@@ -1,9 +1,4 @@
-from datetime import datetime, date
-
-from calendar_utils import get_relative_counts, build_day_segments
-
-from datetime import datetime, date, timedelta
-
+from datetime import date, datetime, timedelta
 from calendar_utils import get_relative_counts, build_day_segments, _get_date_range
 from hourly_cache import HourlyEventCache
 


### PR DESCRIPTION
## Summary
- correct calendar utils test imports by consolidating and adding missing items

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test` *(fails: duplicate key `rusqlite` in table `dependencies`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8282d1f208322aa165d8a33c3a523