### PR TITLE
Add package initializers

### DIFF
--- a/Pelican/__init__.py
+++ b/Pelican/__init__.py
@@ -1,0 +1,1 @@
+"""Pelican package."""

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integrations package."""


### PR DESCRIPTION
## Summary
- ensure Pelican and integrations directories are importable by adding `__init__.py` files

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_generate_html_timeline_item.py tests/test_medical_record_connector.py tests/test_news_api.py tests/test_transaction_analysis.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test` *(fails: mismatched closing delimiter in `src/scanner.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad575596648322af4828a269598bfb