### PR TITLE
Clean up duplicate config tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,43 +34,10 @@ def test_set_and_get_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert TircorderConfig.get_config() == data
 
 
-def test_get_config_returns_empty_when_missing(
+def test_get_config_missing_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Missing config file should return an empty dictionary."""
     path = tmp_path / "missing.json"
     monkeypatch.setenv("TIRCORDER_CONFIG_PATH", str(path))
-
-import importlib.util
-from pathlib import Path
-
-spec = importlib.util.spec_from_file_location(
-    "tircorder.interfaces.config",
-    Path(__file__).resolve().parent.parent / "tircorder" / "interfaces" / "config.py",
-)
-config_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(config_module)
-TircorderConfig = config_module.TircorderConfig
-
-
-def test_set_and_get_config(tmp_path, monkeypatch):
-    config_path = tmp_path / "config.json"
-    monkeypatch.setenv("TIRCORDER_CONFIG_PATH", str(config_path))
-
-    data = {
-        "api_base_url": "https://api.example.com",
-        "export_format": "json",
-        "output_path": str(tmp_path / "out"),
-    }
-    TircorderConfig.set_config(data)
-    assert config_path.exists()
-
-    loaded = TircorderConfig.get_config()
-    assert loaded == data
-
-
-def test_get_config_missing_file(tmp_path, monkeypatch):
-    config_path = tmp_path / "config.json"
-    monkeypatch.setenv("TIRCORDER_CONFIG_PATH", str(config_path))
-
     assert TircorderConfig.get_config() == {}


### PR DESCRIPTION
## Summary
- streamline `tests/test_config.py` by using a single import block
- drop duplicate tests and keep unique coverage for config persistence

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_config.py -q` *(fails: SyntaxError in tircorder/interfaces/config.py)*
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test` *(fails: mismatched closing delimiter in src/scanner.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68ad576570fc8322ad38b706bfdb9b3a