### PR TITLE
Handle optional requests dependency

### DIFF
--- a/integrations/news_api.py
+++ b/integrations/news_api.py
@@ -1,9 +1,18 @@
-"""Retrieve news articles for a specific day using the NewsAPI service."""
+"""Retrieve news articles for a specific day using the NewsAPI service.
+
+This module requires the optional :mod:`requests` dependency.
+"""
 
 from datetime import date
 from typing import Dict, List, Union
 
-import requests
+try:  # pragma: no cover - exercised in import tests
+    import requests
+except ImportError as exc:  # pragma: no cover - handled via tests
+    raise ImportError(
+        "The `requests` package is required to use the News API integration. "
+        "Install it with `pip install requests`."
+    ) from exc
 
 BASE_URL = "https://newsapi.org/v2/everything"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ ctranslate2==4.3.0
 faster-whisper==0.10.0
 librosa==0.10.1
 vaderSentiment==3.3.2
-requests==2.32.3
+# Optional dependencies
+# requests==2.32.3  # Needed for integrations.news_api and rule_check_client
 ofxparse==0.21
 qifparse==0.3.5
 piecash==1.1.0

--- a/tircorder/interfaces/rule_check_client.py
+++ b/tircorder/interfaces/rule_check_client.py
@@ -1,11 +1,20 @@
-"""Clients for checking event compliance via Sensiblaw."""
+"""Clients for checking event compliance via Sensiblaw.
+
+This module requires the optional :mod:`requests` dependency.
+"""
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
-import requests
+try:  # pragma: no cover - exercised in import tests
+    import requests
+except ImportError as exc:  # pragma: no cover - handled via tests
+    raise ImportError(
+        "The `requests` package is required to use `HTTPRuleCheckClient`. "
+        "Install it with `pip install requests`."
+    ) from exc
 
 
 class RuleCheckClient(ABC):


### PR DESCRIPTION
## Summary
- guard News API integration and rule check client against missing `requests` with clear errors
- document `requests` as optional and comment in requirements

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test` *(fails: mismatched closing delimiter in src/scanner.rs)*
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_news_api.py tests/test_rule_check_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad5ea2d24c8322a8fc184f077a84ea