### PR TITLE
Ensure config module imports future annotations at top

### DIFF
--- a/tircorder/interfaces/config.py
+++ b/tircorder/interfaces/config.py
@@ -1,5 +1,4 @@
 """Configuration utilities for Tircorder interfaces."""
-
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- place future annotations import directly after module docstring
- keep only a single `TircorderConfig` definition for persistence utilities

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test` *(fails: mismatched closing delimiter in src/scanner.rs)*
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad5ea303ac8322bfe3e9d37519d2d3