### PR TITLE
Simplify test imports with shared path setup

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import sys, pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,21 +1,11 @@
 """Tests for TircorderConfig persistence utilities."""
 
 import json
-import importlib.util
 from pathlib import Path
 
 import pytest
 
-MODULE_PATH = (
-    Path(__file__).resolve().parent.parent / "tircorder" / "interfaces" / "config.py"
-)
-SPEC = importlib.util.spec_from_file_location(
-    "tircorder.interfaces.config", MODULE_PATH
-)
-config_module = importlib.util.module_from_spec(SPEC)
-assert SPEC.loader is not None
-SPEC.loader.exec_module(config_module)
-TircorderConfig = config_module.TircorderConfig
+from tircorder.interfaces.config import TircorderConfig
 
 
 def test_set_and_get_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_rule_check_client.py
+++ b/tests/test_rule_check_client.py
@@ -1,12 +1,6 @@
-import importlib.util
 import requests
 
-spec = importlib.util.spec_from_file_location(
-    "rule_check_client", "tircorder/interfaces/rule_check_client.py"
-)
-module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(module)
-HTTPRuleCheckClient = module.HTTPRuleCheckClient
+from tircorder.interfaces.rule_check_client import HTTPRuleCheckClient
 
 
 class DummyResponse:

--- a/tests/test_story_exporter.py
+++ b/tests/test_story_exporter.py
@@ -1,20 +1,7 @@
-import importlib.util
 import json
-import sys
 from pathlib import Path
 
-MODULE_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "tircorder"
-    / "interfaces"
-    / "story_exporter.py"
-)
-
-spec = importlib.util.spec_from_file_location("story_exporter", MODULE_PATH)
-story_exporter = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = story_exporter
-spec.loader.exec_module(story_exporter)
-JSONStoryExporter = story_exporter.JSONStoryExporter
+from tircorder.interfaces.story_exporter import JSONStoryExporter
 
 
 def test_json_story_exporter_round_trip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- insert project root into `sys.path` for tests
- replace ad-hoc module loading with standard imports

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test` *(fails: mismatched closing delimiter in scanner.rs)*
- `PYENV_VERSION=3.10.17 pytest -q tircorder-JOBBIE/tests/test_config.py tircorder-JOBBIE/tests/test_rule_check_client.py tircorder-JOBBIE/tests/test_story_exporter.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad5ea9b25c832286aa8528a83aa920