### PR TITLE
Add Apple Health connector and tests

### DIFF
--- a/integrations/fitness/__init__.py
+++ b/integrations/fitness/__init__.py
@@ -1,0 +1,5 @@
+"""Fitness tracking connectors."""
+
+from .apple_health import AppleHealthConnector
+
+__all__ = ["AppleHealthConnector"]

--- a/integrations/fitness/apple_health.py
+++ b/integrations/fitness/apple_health.py
@@ -1,0 +1,139 @@
+"""Apple Health integration utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List
+from uuid import uuid4
+from xml.etree import ElementTree as ET
+
+from tircorder.schemas import validate_story
+
+
+class AppleHealthConnector:
+    """Parse data from Apple Health exports or a native bridge."""
+
+    def fetch_bridge(self) -> List[Dict]:
+        """Placeholder for a native bridge integration."""
+        raise NotImplementedError("Native bridge integration not yet implemented")
+
+    def load_export(self, path: str) -> List[Dict]:
+        """Load events from a HealthKit ``export.xml`` file.
+
+        Parameters
+        ----------
+        path:
+            Location of the ``export.xml`` file.
+
+        Returns
+        -------
+        list of dict
+            Story events parsed from the file.
+
+        Raises
+        ------
+        ValueError
+            If the XML is malformed or cannot be read.
+        """
+
+        try:
+            root = ET.parse(path).getroot()
+        except (
+            ET.ParseError,
+            FileNotFoundError,
+        ) as exc:  # pragma: no cover - file missing
+            raise ValueError("Invalid HealthKit export") from exc
+
+        events: List[Dict] = []
+
+        for record in root.findall("Record"):
+            rtype = record.get("type")
+            start = record.get("startDate")
+            end = record.get("endDate")
+            if not rtype or not start:
+                continue
+            try:
+                ts = datetime.fromisoformat(start.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+
+            if rtype == "HKQuantityTypeIdentifierStepCount":
+                value = record.get("value")
+                if value is None:
+                    continue
+                event = {
+                    "event_id": f"apple_health_steps_{uuid4()}",
+                    "timestamp": ts.isoformat(),
+                    "actor": "user",
+                    "action": "steps",
+                    "details": {"count": int(value), "start": start, "end": end},
+                }
+                validate_story(event)
+                events.append(event)
+
+            elif rtype == "HKQuantityTypeIdentifierHeartRate":
+                value = record.get("value")
+                unit = record.get("unit")
+                if value is None:
+                    continue
+                event = {
+                    "event_id": f"apple_health_hr_{uuid4()}",
+                    "timestamp": ts.isoformat(),
+                    "actor": "user",
+                    "action": "heart_rate",
+                    "details": {"bpm": float(value), "unit": unit},
+                }
+                validate_story(event)
+                events.append(event)
+
+            elif rtype == "HKCategoryTypeIdentifierSleepAnalysis":
+                state = record.get("value")
+                if state is None:
+                    continue
+                event = {
+                    "event_id": f"apple_health_sleep_{uuid4()}",
+                    "timestamp": ts.isoformat(),
+                    "actor": "user",
+                    "action": "sleep",
+                    "details": {"state": state, "start": start, "end": end},
+                }
+                validate_story(event)
+                events.append(event)
+
+        for workout in root.findall("Workout"):
+            start = workout.get("startDate")
+            if not start:
+                continue
+            try:
+                ts = datetime.fromisoformat(start.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            activity = workout.get("workoutActivityType", "")
+            details = {
+                "activity": activity.replace("HKWorkoutActivityType", "").lower(),
+                "duration": _to_float(workout.get("duration")),
+                "energy_burned": _to_float(workout.get("totalEnergyBurned")),
+                "distance": _to_float(workout.get("totalDistance")),
+            }
+            event = {
+                "event_id": f"apple_health_workout_{uuid4()}",
+                "timestamp": ts.isoformat(),
+                "actor": "user",
+                "action": "workout",
+                "details": details,
+            }
+            validate_story(event)
+            events.append(event)
+
+        return events
+
+
+def _to_float(value: str | None) -> float | None:
+    """Convert *value* to ``float`` if possible."""
+
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None

--- a/tests/data/apple_health_export.xml
+++ b/tests/data/apple_health_export.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<HealthData>
+  <Record type="HKQuantityTypeIdentifierStepCount" startDate="2024-05-01T10:00:00Z" endDate="2024-05-01T10:10:00Z" value="100"/>
+  <Record type="HKQuantityTypeIdentifierStepCount" startDate="2024-05-01T11:00:00Z" endDate="2024-05-01T11:10:00Z"/>
+  <Record type="HKQuantityTypeIdentifierHeartRate" unit="count/min" startDate="2024-05-01T10:05:00Z" endDate="2024-05-01T10:05:00Z" value="80"/>
+  <Record type="HKCategoryTypeIdentifierSleepAnalysis" value="Asleep" startDate="2024-05-01T00:00:00Z" endDate="2024-05-01T06:00:00Z"/>
+  <Workout workoutActivityType="HKWorkoutActivityTypeRunning" duration="1800" totalEnergyBurned="300" totalDistance="5" startDate="2024-05-01T07:00:00Z" endDate="2024-05-01T07:30:00Z"/>
+</HealthData>

--- a/tests/test_apple_health.py
+++ b/tests/test_apple_health.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from integrations.fitness.apple_health import AppleHealthConnector
+
+
+def test_load_export():
+    connector = AppleHealthConnector()
+    path = Path("tests/data/apple_health_export.xml")
+    events = connector.load_export(str(path))
+    assert len(events) == 4
+    actions = {e["action"] for e in events}
+    assert actions == {"steps", "heart_rate", "sleep", "workout"}
+    step_event = next(e for e in events if e["action"] == "steps")
+    assert step_event["details"]["count"] == 100
+    workout_event = next(e for e in events if e["action"] == "workout")
+    assert workout_event["details"]["activity"] == "running"
+
+
+def test_load_export_bad_xml(tmp_path):
+    bad = tmp_path / "bad.xml"
+    bad.write_text("<HealthData><Record></HealthData>", encoding="utf-8")
+    connector = AppleHealthConnector()
+    with pytest.raises(ValueError):
+        connector.load_export(str(bad))


### PR DESCRIPTION
## Summary
- add AppleHealthConnector to parse HealthKit exports into story events
- include sample export and unit tests with malformed XML coverage

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_apple_health.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae915ef7108322983c148dff362d2f