### PR TITLE
Add Twitter backup parser and tests

### DIFF
--- a/docs/twitter_backup.md
+++ b/docs/twitter_backup.md
@@ -1,0 +1,25 @@
+# Twitter Backup Integration
+
+TiRCorder can ingest data from Twitter's self-service data export. The download
+contains JavaScript files such as `tweet.js`, `like.js`, and direct message
+archives. Each file wraps the JSON payload in a variable assignment, e.g.:
+
+```javascript
+window.YTD.tweet.part0 = [ { "tweet": { ... } } ];
+```
+
+To parse these files the prefix and trailing semicolon must be stripped before
+loading the JSON content.
+
+## Direct Messages
+
+Direct messages are grouped by conversation and exposed under the
+`dmConversation` key. Each message has `messageCreate` metadata including
+`createdAt`, `senderId`, and `text` fields.
+
+## API and Rate Limits
+
+Twitter's API enforces strict quotas. As of 2024 the free tier allows only a
+small number of read requests per day and roughly 1,500 posts per month.
+Downloading an archive avoids these limits but the export is only generated on
+demand and may take hours to prepare.

--- a/integrations/twitter_backup.py
+++ b/integrations/twitter_backup.py
@@ -1,0 +1,112 @@
+"""Parse Twitter data download archives."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from tircorder.schemas import validate_story
+
+
+class TwitterBackupConnector:
+    """Convert Twitter data export files into story events.
+
+    Twitter's self-service data download returns JavaScript files such as
+    ``tweet.js`` and ``like.js`` where the JSON payload is assigned to a global
+    variable.  Direct message archives are similarly wrapped and may be split
+    across multiple files.
+
+    This connector extracts the JSON arrays from those files and converts each
+    record into a standard story event validated against
+    :func:`tircorder.schemas.validate_story`.
+    """
+
+    def _load_js(self, path: str) -> List[Dict]:
+        """Load a JavaScript data file into a Python object."""
+        text = Path(path).read_text(encoding="utf-8")
+        start = text.find("[")
+        end = text.rfind("]")
+        if start == -1 or end == -1:
+            return []
+        return json.loads(text[start : end + 1])
+
+    def _parse_time(self, value: str) -> str:
+        """Normalise timestamp strings to ISO 8601."""
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).isoformat()
+        except ValueError:
+            dt = datetime.strptime(value, "%a %b %d %H:%M:%S %z %Y")
+            return dt.isoformat()
+
+    def parse_tweets(self, path: str) -> List[Dict]:
+        """Parse ``tweet.js`` into story events."""
+        records = self._load_js(path)
+        events: List[Dict] = []
+        for item in records:
+            tweet = item.get("tweet", {})
+            tweet_id = tweet.get("id") or tweet.get("id_str")
+            created_at = tweet.get("created_at") or tweet.get("createdAt")
+            text = tweet.get("full_text") or tweet.get("fullText") or tweet.get("text")
+            if not tweet_id or not created_at:
+                continue
+            event = {
+                "event_id": f"tweet_{tweet_id}",
+                "timestamp": self._parse_time(created_at),
+                "actor": "user",
+                "action": "tweet",
+                "details": {"id": tweet_id, "text": text},
+            }
+            validate_story(event)
+            events.append(event)
+        return events
+
+    def parse_likes(self, path: str) -> List[Dict]:
+        """Parse ``like.js`` into story events."""
+        records = self._load_js(path)
+        events: List[Dict] = []
+        for item in records:
+            like = item.get("like", {})
+            tweet_id = like.get("tweetId")
+            created_at = like.get("createdAt")
+            text = like.get("fullText")
+            url = like.get("expandedUrl")
+            if not tweet_id or not created_at:
+                continue
+            event = {
+                "event_id": f"like_{tweet_id}",
+                "timestamp": self._parse_time(created_at),
+                "actor": "user",
+                "action": "like",
+                "details": {"tweet_id": tweet_id, "text": text, "url": url},
+            }
+            validate_story(event)
+            events.append(event)
+        return events
+
+    def parse_messages(self, path: str) -> List[Dict]:
+        """Parse direct message archives into story events."""
+        records = self._load_js(path)
+        events: List[Dict] = []
+        for conv in records:
+            dm_conv = conv.get("dmConversation", {})
+            conv_id = dm_conv.get("conversationId")
+            for msg in dm_conv.get("messages", []):
+                m = msg.get("messageCreate", {})
+                msg_id = m.get("id")
+                created_at = m.get("createdAt")
+                sender = m.get("senderId")
+                text = m.get("text")
+                if not msg_id or not created_at:
+                    continue
+                event = {
+                    "event_id": f"dm_{msg_id}",
+                    "timestamp": self._parse_time(created_at),
+                    "actor": sender or "user",
+                    "action": "dm",
+                    "details": {"conversation_id": conv_id, "text": text},
+                }
+                validate_story(event)
+                events.append(event)
+        return events

--- a/tests/test_twitter_backup.py
+++ b/tests/test_twitter_backup.py
@@ -1,0 +1,40 @@
+from integrations.twitter_backup import TwitterBackupConnector
+
+
+def test_parse_tweets(tmp_path):
+    sample = (
+        "window.YTD.tweet.part0 = ["
+        '{"tweet":{"id":"1","created_at":"2024-05-10T12:34:56.000Z",'
+        '"full_text":"hello"}}];'
+    )
+    p = tmp_path / "tweet.js"
+    p.write_text(sample, encoding="utf-8")
+    connector = TwitterBackupConnector()
+    events = connector.parse_tweets(str(p))
+    assert len(events) == 1
+    event = events[0]
+    assert event["event_id"] == "tweet_1"
+    assert event["action"] == "tweet"
+    assert event["details"]["text"] == "hello"
+
+
+def test_parse_messages(tmp_path):
+    sample = (
+        "window.YTD.direct_message.part0 = ["
+        '{\n  "dmConversation": {\n    "conversationId": "u-u",\n'
+        '    "messages": [\n      {\n        "messageCreate": {\n'
+        '          "id": "2",\n'
+        '          "createdAt": "2024-05-10T13:00:00.000Z",\n'
+        '          "senderId": "123",\n'
+        '          "text": "hi"\n        }\n      }\n    ]\n  }\n}];'
+    )
+    p = tmp_path / "dm.js"
+    p.write_text(sample, encoding="utf-8")
+    connector = TwitterBackupConnector()
+    events = connector.parse_messages(str(p))
+    assert len(events) == 1
+    event = events[0]
+    assert event["event_id"] == "dm_2"
+    assert event["actor"] == "123"
+    assert event["details"]["conversation_id"] == "u-u"
+    assert event["details"]["text"] == "hi"


### PR DESCRIPTION
## Summary
- implement TwitterBackupConnector to convert tweet, like, and DM exports into story events
- document Twitter data-download quirks and rate limits
- add tests for tweet and direct message parsing

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_twitter_backup.py -q`
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9228b1a08322b8e29f486fc9c89f