### PR TITLE
Add Instagram backup connector and tests

### DIFF
--- a/integrations/instagram_backup.py
+++ b/integrations/instagram_backup.py
@@ -1,0 +1,51 @@
+"""Parse Instagram data download JSON exports into story events."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from tircorder.schemas import validate_story
+
+
+class InstagramBackupConnector:
+    """Load posts, stories and messages from an Instagram data download."""
+
+    def __init__(self, base_path: str | Path) -> None:
+        """Initialise connector with the path to an export directory."""
+        self.base_path = Path(base_path)
+
+    def load(self) -> List[Dict[str, Any]]:
+        """Return validated story events from the export directory."""
+        events: List[Dict[str, Any]] = []
+        events.extend(self._load_items(self.base_path / "posts.json", "post"))
+        events.extend(self._load_items(self.base_path / "stories.json", "story"))
+        events.extend(self._load_items(self.base_path / "messages.json", "message"))
+        return events
+
+    def _load_items(self, filepath: Path, action: str) -> List[Dict[str, Any]]:
+        """Parse *filepath* for events with the given *action*."""
+        if not filepath.exists():
+            return []
+        with open(filepath, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        events: List[Dict[str, Any]] = []
+        for item in data:
+            timestamp = item.get("timestamp")
+            if not timestamp:
+                raise ValueError(f"Missing timestamp in {action} item: {item}")
+            if action in {"post", "story"} and not item.get("media"):
+                raise ValueError(f"Missing media in {action} item at {timestamp}")
+            event: Dict[str, Any] = {
+                "event_id": str(item.get("id", "")),
+                "timestamp": timestamp,
+                "actor": "instagram",
+                "action": action,
+                "details": {
+                    k: v for k, v in item.items() if k not in {"id", "timestamp"}
+                },
+            }
+            validate_story(event)
+            events.append(event)
+        return events

--- a/tests/test_instagram_backup.py
+++ b/tests/test_instagram_backup.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from integrations.instagram_backup import InstagramBackupConnector
+
+
+def write_json(path: Path, data: list) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_instagram_backup_connector_parses_events(tmp_path: Path) -> None:
+    posts = [
+        {
+            "id": "p1",
+            "timestamp": "2024-01-01T12:00:00+00:00",
+            "caption": "hello",
+            "media": "photo.jpg",
+        }
+    ]
+    stories = [
+        {
+            "id": "s1",
+            "timestamp": "2024-01-02T12:00:00+00:00",
+            "media": "story.jpg",
+        }
+    ]
+    messages = [
+        {
+            "id": "m1",
+            "timestamp": "2024-01-03T12:00:00+00:00",
+            "sender": "alice",
+            "text": "hi",
+        }
+    ]
+
+    write_json(tmp_path / "posts.json", posts)
+    write_json(tmp_path / "stories.json", stories)
+    write_json(tmp_path / "messages.json", messages)
+
+    connector = InstagramBackupConnector(tmp_path)
+    events = connector.load()
+
+    assert len(events) == 3
+    assert {e["action"] for e in events} == {"post", "story", "message"}
+
+
+def test_instagram_backup_connector_missing_fields(tmp_path: Path) -> None:
+    posts = [{"id": "p1", "caption": "no timestamp", "media": "p.jpg"}]
+    write_json(tmp_path / "posts.json", posts)
+
+    connector = InstagramBackupConnector(tmp_path)
+    with pytest.raises(ValueError):
+        connector.load()
+
+    posts = [
+        {
+            "id": "p2",
+            "timestamp": "2024-01-01T12:00:00+00:00",
+            "caption": "no media",
+        }
+    ]
+    write_json(tmp_path / "posts.json", posts)
+    with pytest.raises(ValueError):
+        connector.load()


### PR DESCRIPTION
## Summary
- parse Instagram data export posts, stories, and messages into validated story events
- raise errors for missing timestamps or media
- add unit tests covering normal and error cases

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_instagram_backup.py -q`
- `cargo test >/tmp/cargo_test.log && tail -n 20 /tmp/cargo_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68ae92276e2c832287c59c2ba790e2ea