### PR TITLE
Add LinkedIn backup connector

### DIFF
--- a/integrations/linkedin_backup.py
+++ b/integrations/linkedin_backup.py
@@ -1,0 +1,126 @@
+"""Parse LinkedIn data export files into story events."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+from uuid import uuid4
+
+from tircorder.schemas import validate_story
+
+
+class LinkedInBackupConnector:
+    """Load timeline events from a LinkedIn data export directory."""
+
+    def __init__(self, export_dir: str | Path) -> None:
+        self.export_dir = Path(export_dir)
+
+    def load_events(self) -> List[Dict]:
+        """Return story events from the export directory."""
+
+        events: List[Dict] = []
+        events.extend(self._load_messages())
+        events.extend(self._load_profile_updates())
+        events.extend(self._load_posts())
+        return events
+
+    def _load_messages(self) -> List[Dict]:
+        path = self.export_dir / "messages.csv"
+        if not path.exists():
+            return []
+        events: List[Dict] = []
+        with open(path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                ts = self._parse_ts(row.get("Date"))
+                if not ts:
+                    continue
+                event = {
+                    "event_id": f"linkedin_msg_{uuid4()}",
+                    "timestamp": ts,
+                    "actor": row.get("From") or "unknown",
+                    "action": "message",
+                    "details": {
+                        "to": row.get("To"),
+                        "text": row.get("Message", ""),
+                    },
+                }
+                validate_story(event)
+                events.append(event)
+        return events
+
+    def _load_profile_updates(self) -> List[Dict]:
+        path = self.export_dir / "profile_updates.json"
+        if not path.exists():
+            return []
+        with open(path, "r", encoding="utf-8") as fh:
+            raw_items = json.load(fh)
+        events: List[Dict] = []
+        for item in raw_items:
+            ts = self._parse_ts(item.get("timestamp"))
+            if not ts:
+                continue
+            event = {
+                "event_id": f"linkedin_profile_{uuid4()}",
+                "timestamp": ts,
+                "actor": "user",
+                "action": "profile_update",
+                "details": {
+                    "update": item.get("update"),
+                    "location": item.get("location"),
+                },
+            }
+            validate_story(event)
+            events.append(event)
+        return events
+
+    def _load_posts(self) -> List[Dict]:
+        path = self.export_dir / "posts.json"
+        if not path.exists():
+            return []
+        with open(path, "r", encoding="utf-8") as fh:
+            raw_items = json.load(fh)
+        events: List[Dict] = []
+        for item in raw_items:
+            ts = self._parse_ts(item.get("timestamp"))
+            if not ts:
+                continue
+            event = {
+                "event_id": f"linkedin_post_{uuid4()}",
+                "timestamp": ts,
+                "actor": "user",
+                "action": "post",
+                "details": {
+                    "text": item.get("text"),
+                    "url": item.get("url"),
+                },
+            }
+            validate_story(event)
+            events.append(event)
+        return events
+
+    @staticmethod
+    def _parse_ts(ts: str | None) -> str | None:
+        if not ts:
+            return None
+        cleaned = ts.strip().replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(cleaned)
+        except ValueError:
+            dt = None
+            for fmt in ("%Y-%m-%d %H:%M:%S %z", "%Y-%m-%dT%H:%M:%S%z"):
+                try:
+                    dt = datetime.strptime(cleaned, fmt)
+                    break
+                except ValueError:
+                    continue
+            if dt is None:
+                return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt.isoformat()

--- a/tests/test_linkedin_backup.py
+++ b/tests/test_linkedin_backup.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from typing import List, Dict
+
+from integrations.linkedin_backup import LinkedInBackupConnector
+from tircorder.schemas import validate_story
+
+
+def create_sample_export(base: Path) -> None:
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "messages.csv").write_text(
+        """Date,From,To,Message
+2024-06-01 10:00:00 +0000,Alice,Bob,Hello Bob
+2024-06-01 11:00:00 +0100,Bob,Alice,
+""",
+        encoding="utf-8",
+    )
+    (base / "profile_updates.json").write_text(
+        """[
+  {"timestamp": "2024-06-02T09:00:00Z", "update": "Changed headline"},
+  {"timestamp": "2024-06-03 15:30:00 +0200", "update": "Updated location", "location": "Paris"}
+]
+""",
+        encoding="utf-8",
+    )
+    (base / "posts.json").write_text(
+        """[
+  {"timestamp": "2024-06-04T12:00:00", "text": "New post!"},
+  {"timestamp": "2024-06-05T08:00:00-0500", "text": "Another post", "url": "https://example.com/post"}
+]
+""",
+        encoding="utf-8",
+    )
+
+
+def test_linkedin_backup_connector_parses_exports(tmp_path: Path) -> None:
+    export_dir = tmp_path / "linkedin"
+    create_sample_export(export_dir)
+
+    connector = LinkedInBackupConnector(export_dir)
+    events: List[Dict] = connector.load_events()
+
+    assert len(events) == 6
+    actions = {e["action"] for e in events}
+    assert actions == {"message", "profile_update", "post"}
+
+    # time zone normalization: second message +0100 -> 10:00 UTC
+    msg = [e for e in events if e["action"] == "message"]
+    second = msg[1]
+    assert second["timestamp"].startswith("2024-06-01T10:00:00")
+    assert second["timestamp"].endswith("+00:00")
+    assert second["details"]["text"] == ""
+
+    for event in events:
+        validate_story(event)


### PR DESCRIPTION
## Summary
- add LinkedInBackupConnector for parsing LinkedIn message/profile/post exports into story events
- normalize timestamps to UTC and validate story schema
- test LinkedIn connector with sample exports

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_linkedin_backup.py -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae922b35088322bbdb89323492a4df