### PR TITLE
Add Google Takeout connector

### DIFF
--- a/integrations/google_takeout.py
+++ b/integrations/google_takeout.py
@@ -1,0 +1,136 @@
+"""Utilities for parsing Google Takeout archives."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterator
+from uuid import uuid4
+import json
+
+from tircorder.schemas import validate_story
+
+
+class GoogleTakeoutConnector:
+    """Parse selected Google Takeout JSON exports into story events.
+
+    Parameters
+    ----------
+    base_path:
+        Root directory of the extracted Takeout archive.
+    """
+
+    def __init__(self, base_path: str | Path) -> None:
+        self.base_path = Path(base_path)
+
+    def iter_events(self) -> Iterator[Dict]:
+        """Yield events parsed from supported Takeout files."""
+
+        yield from self._parse_gmail_all_mail()
+        yield from self._parse_drive_activity()
+        yield from self._parse_photos_metadata()
+
+    # Internal helpers -------------------------------------------------
+    def _load_json_items(self, path: Path) -> Iterator[Dict]:
+        """Yield JSON objects from ``path``.
+
+        Supports newline-delimited JSON or arrays.  Malformed lines are skipped.
+        """
+
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                start = fh.read(1)
+                fh.seek(0)
+                if start == "[":
+                    try:
+                        data = json.load(fh)
+                    except json.JSONDecodeError:
+                        return
+                    for item in data:
+                        if isinstance(item, dict):
+                            yield item
+                else:
+                    for line in fh:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            item = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if isinstance(item, dict):
+                            yield item
+        except OSError:
+            return
+
+    def _parse_gmail_all_mail(self) -> Iterator[Dict]:
+        path = self.base_path / "Gmail" / "All mail.json"
+        for item in self._load_json_items(path):
+            ts = item.get("timestamp") or item.get("internalDate")
+            if not ts:
+                continue
+            try:
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            event = {
+                "event_id": f"gmail_{item.get('id', uuid4())}",
+                "timestamp": dt.isoformat(),
+                "actor": item.get("from", "unknown"),
+                "action": "email",
+                "details": {
+                    "subject": item.get("subject"),
+                    "snippet": item.get("snippet"),
+                },
+            }
+            try:
+                validate_story(event)
+            except Exception:
+                continue
+            yield event
+
+    def _parse_drive_activity(self) -> Iterator[Dict]:
+        path = self.base_path / "Drive" / "Activity.json"
+        for item in self._load_json_items(path):
+            ts = item.get("time") or item.get("timestamp")
+            if not ts:
+                continue
+            try:
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            event = {
+                "event_id": f"drive_{uuid4()}",
+                "timestamp": dt.isoformat(),
+                "actor": item.get("actor", "user"),
+                "action": item.get("action", "activity"),
+                "details": {"target": item.get("target")},
+            }
+            try:
+                validate_story(event)
+            except Exception:
+                continue
+            yield event
+
+    def _parse_photos_metadata(self) -> Iterator[Dict]:
+        path = self.base_path / "Google Photos" / "metadata.json"
+        for item in self._load_json_items(path):
+            ts = item.get("creationTime") or item.get("timestamp")
+            if not ts:
+                continue
+            try:
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            event = {
+                "event_id": f"photo_{uuid4()}",
+                "timestamp": dt.isoformat(),
+                "actor": "user",
+                "action": "photo",
+                "details": {"file_name": item.get("fileName")},
+            }
+            try:
+                validate_story(event)
+            except Exception:
+                continue
+            yield event

--- a/tests/test_google_takeout.py
+++ b/tests/test_google_takeout.py
@@ -1,0 +1,71 @@
+"""Tests for GoogleTakeoutConnector."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from integrations.google_takeout import GoogleTakeoutConnector
+
+
+def _write_json_lines(path: Path, items: list) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for obj in items:
+            fh.write(json.dumps(obj) + "\n")
+        fh.write("not json\n")
+
+
+def _create_takeout(tmp_path: Path) -> Path:
+    gmail_dir = tmp_path / "Gmail"
+    gmail_dir.mkdir()
+    gmail_file = gmail_dir / "All mail.json"
+    gmail_items = [
+        {
+            "id": "1",
+            "timestamp": "2024-01-02T03:04:05Z",
+            "from": "alice@example.com",
+            "subject": "Hello",
+            "snippet": "Hi",
+        },
+        {"id": "2", "timestamp": "bad"},
+    ]
+    _write_json_lines(gmail_file, gmail_items)
+
+    drive_dir = tmp_path / "Drive"
+    drive_dir.mkdir()
+    drive_file = drive_dir / "Activity.json"
+    drive_items = [
+        {
+            "time": "2024-01-02T04:00:00Z",
+            "actor": "user",
+            "action": "edit",
+            "target": "doc1",
+        }
+    ]
+    with open(drive_file, "w", encoding="utf-8") as fh:
+        json.dump(drive_items, fh)
+
+    photos_dir = tmp_path / "Google Photos"
+    photos_dir.mkdir()
+    photos_file = photos_dir / "metadata.json"
+    photos_items = [{"creationTime": "2024-01-01T00:00:00Z", "fileName": "img1.jpg"}]
+    with open(photos_file, "w", encoding="utf-8") as fh:
+        json.dump(photos_items, fh)
+
+    return tmp_path
+
+
+def test_google_takeout_connector(tmp_path: Path) -> None:
+    base = _create_takeout(tmp_path)
+    connector = GoogleTakeoutConnector(base)
+    events = list(connector.iter_events())
+    assert len(events) == 3
+
+    email = next(e for e in events if e["action"] == "email")
+    assert email["details"]["subject"] == "Hello"
+
+    drive = next(e for e in events if e["action"] == "edit")
+    assert drive["details"]["target"] == "doc1"
+
+    photo = next(e for e in events if e["action"] == "photo")
+    assert photo["details"]["file_name"] == "img1.jpg"


### PR DESCRIPTION
## Summary
- add `GoogleTakeoutConnector` to parse Gmail, Drive, and Photos Takeout JSON into story events
- handle streaming JSON parsing and malformed items gracefully
- cover connector with unit test using sample Takeout extracts

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_google_takeout.py -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae9222dcf0832298079950528199e9