### PR TITLE
Add Slack workspace backup connector

### DIFF
--- a/integrations/slack_backup.py
+++ b/integrations/slack_backup.py
@@ -1,0 +1,70 @@
+"""Parse Slack workspace export archives."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+from uuid import uuid4
+
+from tircorder.schemas import validate_story
+
+
+class SlackBackupConnector:
+    """Load messages from a Slack workspace export."""
+
+    def __init__(self, export_path: str) -> None:
+        self.export_path = Path(export_path)
+
+    def load_messages(self) -> List[Dict]:
+        """Return story events parsed from channel JSON files.
+
+        The connector walks the export directory, reading each channel
+        folder and its daily JSON message files. Messages are converted
+        into story events compatible with ``story.schema.yaml``.
+        """
+        events: List[Dict] = []
+        if not self.export_path.exists():
+            return events
+        for channel_dir in sorted(self.export_path.iterdir()):
+            if not channel_dir.is_dir() or channel_dir.name == "files":
+                continue
+            channel = channel_dir.name
+            for page in sorted(channel_dir.glob("*.json")):
+                with page.open("r", encoding="utf-8") as fh:
+                    messages = json.load(fh)
+                for msg in messages:
+                    ts = msg.get("ts")
+                    if not ts:
+                        continue
+                    try:
+                        timestamp = datetime.fromtimestamp(float(ts)).isoformat()
+                    except (TypeError, ValueError):
+                        continue
+                    subtype = msg.get("subtype")
+                    if subtype == "bot_message":
+                        actor = f"bot:{msg.get('bot_id', 'unknown')}"
+                    elif subtype:
+                        actor = "system"
+                    else:
+                        actor = msg.get("user", "system")
+                    details = {"channel": channel, "text": msg.get("text", "")}
+                    files = []
+                    for file in msg.get("files", []):
+                        name = file.get("name") or file.get("title")
+                        file_id = file.get("id")
+                        candidate = (
+                            self.export_path / "files" / (file_id or "") / (name or "")
+                        )
+                        files.append(str(candidate) if candidate.exists() else name)
+                    if files:
+                        details["files"] = files
+                    event = {
+                        "event_id": f"slack_{uuid4()}",
+                        "timestamp": timestamp,
+                        "actor": actor,
+                        "action": "message",
+                        "details": details,
+                    }
+                    validate_story(event)
+                    events.append(event)
+        return events

--- a/tests/data/slack_export/files/F123/test.txt
+++ b/tests/data/slack_export/files/F123/test.txt
@@ -1,0 +1,1 @@
+dummy file

--- a/tests/data/slack_export/general/2023-01-01.json
+++ b/tests/data/slack_export/general/2023-01-01.json
@@ -1,0 +1,13 @@
+[
+  {
+    "ts": "1610000000.000100",
+    "user": "U123",
+    "text": "Hello world"
+  },
+  {
+    "ts": "1610000001.000200",
+    "subtype": "bot_message",
+    "bot_id": "B123",
+    "text": "I am a bot"
+  }
+]

--- a/tests/data/slack_export/general/2023-01-02.json
+++ b/tests/data/slack_export/general/2023-01-02.json
@@ -1,0 +1,16 @@
+[
+  {
+    "ts": "1610086400.000300",
+    "subtype": "channel_join",
+    "user": "U234",
+    "text": "<@U234> joined the channel"
+  },
+  {
+    "ts": "1610086401.000400",
+    "user": "U123",
+    "text": "See file",
+    "files": [
+      {"id": "F123", "name": "test.txt"}
+    ]
+  }
+]

--- a/tests/test_slack_backup.py
+++ b/tests/test_slack_backup.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from integrations.slack_backup import SlackBackupConnector
+
+
+def test_slack_backup_connector_parses_events():
+    export_dir = Path(__file__).parent / "data" / "slack_export"
+    connector = SlackBackupConnector(str(export_dir))
+    events = connector.load_messages()
+    assert len(events) == 4
+
+    # file reference
+    file_event = next(e for e in events if e["details"].get("files"))
+    file_path = Path(file_event["details"]["files"][0])
+    assert file_path.name == "test.txt"
+    assert file_path.exists()
+
+    # bot message
+    bot_event = next(e for e in events if e["actor"].startswith("bot:"))
+    assert bot_event["details"]["channel"] == "general"
+
+    # system message
+    sys_event = next(e for e in events if e["actor"] == "system")
+    assert sys_event["details"]["channel"] == "general"
+
+    # user message
+    user_event = next(
+        e
+        for e in events
+        if e["actor"] == "U123" and e["details"]["text"] == "Hello world"
+    )
+    assert user_event["details"]["channel"] == "general"


### PR DESCRIPTION
## Summary
- add SlackBackupConnector to parse Slack export archives into story events
- attach file references and classify bot/system messages
- test Slack backup parsing with sample export data

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_slack_backup.py -q`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae92312cdc8322bf6d99126e4eb748