### PR TITLE
Add Apple Maps connector for location history

### DIFF
--- a/integrations/location/__init__.py
+++ b/integrations/location/__init__.py
@@ -1,0 +1,1 @@
+"""Location-related integrations."""

--- a/integrations/location/apple_maps.py
+++ b/integrations/location/apple_maps.py
@@ -1,0 +1,101 @@
+"""Connector for parsing Apple Maps history from device backups."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+from uuid import uuid4
+import plistlib
+
+from tircorder.schemas import validate_story
+
+
+class AppleMapsConnector:
+    """Load route and search history from Apple Maps backups."""
+
+    def load_history(self, backup_dir: str | Path) -> List[Dict]:
+        """Parse maps history from ``backup_dir``.
+
+        Parameters
+        ----------
+        backup_dir:
+            Directory containing ``MapsHistory.plist`` or ``Maps/History``.
+
+        Returns
+        -------
+        list of dict
+            Story events extracted from the history file.
+        """
+
+        history_file = self._find_history_file(Path(backup_dir))
+        if history_file is None:
+            return []
+
+        with open(history_file, "rb") as fh:
+            raw = plistlib.load(fh)
+
+        items = raw.get("historyItems") or raw.get("MSPHistoryItems") or []
+        events: List[Dict] = []
+        for item in items:
+            if item.get("isPrivate"):
+                continue
+
+            dt = self._normalize_time(item)
+            if dt is None:
+                continue
+
+            action = "navigate" if item.get("type") == "route" else "search"
+            details: Dict[str, str] = {}
+            if action == "navigate":
+                start = item.get("start") or item.get("origin")
+                end = item.get("end") or item.get("destination")
+                if start:
+                    details["start"] = start
+                if end:
+                    details["end"] = end
+            else:
+                query = item.get("query") or item.get("displayTitle")
+                if query:
+                    details["query"] = query
+
+            event = {
+                "event_id": f"apple_maps_{uuid4()}",
+                "timestamp": dt.isoformat(),
+                "actor": "user",
+                "action": action,
+                "details": details,
+            }
+            validate_story(event)
+            events.append(event)
+
+        return events
+
+    def _find_history_file(self, root: Path) -> Optional[Path]:
+        """Locate the maps history file within ``root``."""
+        candidates = [root / "MapsHistory.plist", root / "Maps" / "History"]
+        for path in candidates:
+            if path.exists():
+                return path
+        return None
+
+    def _normalize_time(self, item: Dict) -> Optional[datetime]:
+        """Return event time in UTC for ``item``."""
+        dt = item.get("timestamp") or item.get("date")
+        if isinstance(dt, datetime):
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            else:
+                dt = dt.astimezone(timezone.utc)
+            return dt
+        if isinstance(dt, str):
+            try:
+                parsed = datetime.fromisoformat(dt)
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            else:
+                parsed = parsed.astimezone(timezone.utc)
+            return parsed
+        return None

--- a/tests/data/backup_folder/Maps/History
+++ b/tests/data/backup_folder/Maps/History
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>historyItems</key>
+  <array>
+    <dict>
+      <key>query</key><string>Coffee Shop</string>
+      <key>timestamp</key><date>2024-05-01T12:00:00Z</date>
+      <key>type</key><string>search</string>
+    </dict>
+    <dict>
+      <key>timestamp</key><date>2024-05-02T16:00:00Z</date>
+      <key>type</key><string>route</string>
+      <key>start</key><string>Home</string>
+      <key>end</key><string>Office</string>
+    </dict>
+    <dict>
+      <key>query</key><string>Secret Place</string>
+      <key>timestamp</key><date>2024-05-03T10:00:00Z</date>
+      <key>type</key><string>search</string>
+      <key>isPrivate</key><true/>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/tests/data/backup_plist/MapsHistory.plist
+++ b/tests/data/backup_plist/MapsHistory.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>historyItems</key>
+  <array>
+    <dict>
+      <key>query</key><string>Coffee Shop</string>
+      <key>timestamp</key><date>2024-05-01T12:00:00Z</date>
+      <key>type</key><string>search</string>
+    </dict>
+    <dict>
+      <key>timestamp</key><date>2024-05-02T16:00:00Z</date>
+      <key>type</key><string>route</string>
+      <key>start</key><string>Home</string>
+      <key>end</key><string>Office</string>
+    </dict>
+    <dict>
+      <key>query</key><string>Secret Place</string>
+      <key>timestamp</key><date>2024-05-03T10:00:00Z</date>
+      <key>type</key><string>search</string>
+      <key>isPrivate</key><true/>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/tests/test_apple_maps_connector.py
+++ b/tests/test_apple_maps_connector.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from integrations.location.apple_maps import AppleMapsConnector
+
+
+def test_load_history_plist():
+    connector = AppleMapsConnector()
+    backup_dir = Path(__file__).parent / "data" / "backup_plist"
+    events = connector.load_history(backup_dir)
+    assert len(events) == 2
+    search_event = next(e for e in events if e["action"] == "search")
+    assert search_event["details"]["query"] == "Coffee Shop"
+    assert search_event["timestamp"].endswith("+00:00")
+    route_event = next(e for e in events if e["action"] == "navigate")
+    assert route_event["details"]["start"] == "Home"
+    assert route_event["details"]["end"] == "Office"
+
+
+def test_load_history_folder():
+    connector = AppleMapsConnector()
+    backup_dir = Path(__file__).parent / "data" / "backup_folder"
+    events = connector.load_history(backup_dir)
+    assert len(events) == 2


### PR DESCRIPTION
## Summary
- add `AppleMapsConnector` to parse Apple Maps backup history
- skip private records, normalise timestamps and validate story events
- include anonymised sample files and tests

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_apple_maps_connector.py -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae943558548322be8d454d5416df2e