### PR TITLE
Add Foursquare location connector and tests

### DIFF
--- a/integrations/location/__init__.py
+++ b/integrations/location/__init__.py
@@ -1,0 +1,5 @@
+"""Location-based integrations."""
+
+from .foursquare import FoursquareConnector
+
+__all__ = ["FoursquareConnector"]

--- a/integrations/location/foursquare.py
+++ b/integrations/location/foursquare.py
@@ -1,0 +1,128 @@
+"""Foursquare check-in integration.
+
+This connector uses OAuth to obtain an access token and retrieve a user's
+check-ins. Foursquare requires a version string (``v``) in YYYYMMDD format for
+all API calls. The free tier allows roughly 95 requests per minute and about
+5,000 requests per day before returning HTTP 429 responses.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+from urllib.parse import urlencode
+
+try:  # pragma: no cover - exercised in import tests
+    import requests
+except ImportError as exc:  # pragma: no cover - handled via tests
+    raise ImportError(
+        "The `requests` package is required to use the Foursquare integration. "
+        "Install it with `pip install requests`."
+    ) from exc
+
+from tircorder.schemas import validate_story
+
+
+class FoursquareConnector:
+    """Client for Foursquare check-ins.
+
+    Parameters
+    ----------
+    client_id:
+        OAuth client identifier.
+    client_secret:
+        OAuth client secret.
+    redirect_uri:
+        URI registered with the Foursquare application.
+    api_version:
+        API version string in ``YYYYMMDD`` format. Defaults to ``20240601``.
+
+    Notes
+    -----
+    The Foursquare API enforces rate limits. Applications on the free tier are
+    limited to approximately 95 requests per minute and 5,000 requests per day.
+    """
+
+    API_BASE = "https://api.foursquare.com/v2"
+    AUTH_URL = "https://foursquare.com/oauth2/authorize"
+    TOKEN_URL = "https://foursquare.com/oauth2/access_token"
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str,
+        *,
+        api_version: str = "20240601",
+    ) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+        self.api_version = api_version
+        self.access_token: Optional[str] = None
+
+    def get_auth_url(self) -> str:
+        """Return the OAuth authorization URL for user login."""
+        params = {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "redirect_uri": self.redirect_uri,
+        }
+        return f"{self.AUTH_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str) -> str:
+        """Exchange an OAuth *code* for an access token."""
+        data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "grant_type": "authorization_code",
+            "redirect_uri": self.redirect_uri,
+            "code": code,
+        }
+        response = requests.post(self.TOKEN_URL, data=data, timeout=10)
+        response.raise_for_status()
+        token = response.json()["access_token"]
+        self.access_token = token
+        return token
+
+    def fetch_checkins(self, limit: int = 250) -> List[Dict]:
+        """Return recent check-ins for the authenticated user."""
+        if not self.access_token:
+            raise RuntimeError("Access token missing. Call `exchange_code` first.")
+        params = {
+            "oauth_token": self.access_token,
+            "v": self.api_version,
+            "limit": limit,
+        }
+        response = requests.get(
+            f"{self.API_BASE}/users/self/checkins", params=params, timeout=10
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get("response", {}).get("checkins", {}).get("items", [])
+
+    @staticmethod
+    def checkin_to_event(checkin: Dict) -> Dict:
+        """Convert a check-in record into a validated story event."""
+        venue = checkin.get("venue", {})
+        location = venue.get("location", {})
+        event = {
+            "event_id": f"foursquare_{checkin['id']}",
+            "timestamp": datetime.fromtimestamp(
+                checkin["createdAt"], tz=timezone.utc
+            ).isoformat(),
+            "actor": "user",
+            "action": "check-in",
+            "details": {
+                "venue": venue.get("name"),
+                "lat": location.get("lat"),
+                "lon": location.get("lng"),
+            },
+        }
+        validate_story(event)
+        return event
+
+    def fetch_events(self, limit: int = 250) -> List[Dict]:
+        """Retrieve check-ins and return them as validated story events."""
+        checkins = self.fetch_checkins(limit=limit)
+        return [self.checkin_to_event(item) for item in checkins]

--- a/tests/test_foursquare.py
+++ b/tests/test_foursquare.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from integrations.location.foursquare import FoursquareConnector
+
+FAKE_CHECKIN = {
+    "id": "1",
+    "createdAt": 1_714_721_600,
+    "venue": {
+        "name": "Central Perk",
+        "location": {"lat": 40.0, "lng": -73.0},
+    },
+}
+
+
+@patch("integrations.location.foursquare.requests.post")
+def test_exchange_code_sets_token(mock_post: Mock) -> None:
+    connector = FoursquareConnector("id", "secret", "http://localhost")
+    mock_resp = Mock()
+    mock_resp.json.return_value = {"access_token": "abc"}
+    mock_resp.raise_for_status.return_value = None
+    mock_post.return_value = mock_resp
+
+    token = connector.exchange_code("CODE")
+    assert token == "abc"
+    assert connector.access_token == "abc"
+
+
+@patch("integrations.location.foursquare.requests.get")
+def test_fetch_events(mock_get: Mock) -> None:
+    connector = FoursquareConnector("id", "secret", "http://localhost")
+    connector.access_token = "TOKEN"
+
+    mock_resp = Mock()
+    mock_resp.json.return_value = {"response": {"checkins": {"items": [FAKE_CHECKIN]}}}
+    mock_resp.raise_for_status.return_value = None
+    mock_get.return_value = mock_resp
+
+    events = connector.fetch_events()
+    assert len(events) == 1
+    event = events[0]
+    assert event["details"]["venue"] == "Central Perk"
+    assert event["details"]["lat"] == 40.0
+    assert event["details"]["lon"] == -73.0


### PR DESCRIPTION
## Summary
- add OAuth-based FoursquareConnector to retrieve check-ins and convert them to story events
- document Foursquare rate limits and API version usage
- test token exchange and event conversion with mocked check-in payloads

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_foursquare.py -q`
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae943d57308322b95042101583723d