### PR TITLE
Add Waze drive history connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !matches.json
 !dangling_audio.json
 !dangling_transcripts.json
+!tests/data/waze_sample.json
 
 __pycache__/*.*
 __pycache__/

--- a/integrations/location/__init__.py
+++ b/integrations/location/__init__.py
@@ -1,0 +1,5 @@
+"""Location-based connectors."""
+
+from .waze import WazeConnector
+
+__all__ = ["WazeConnector"]

--- a/integrations/location/waze.py
+++ b/integrations/location/waze.py
@@ -1,0 +1,104 @@
+"""Parse Waze drive history exports into story events."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import uuid4
+
+from tircorder.schemas import validate_story
+
+
+class WazeConnector:
+    """Parse Waze drive history exports."""
+
+    def parse_drive_history(self, path: str) -> List[Dict[str, Any]]:
+        """Return story events for each drive in the Waze export at ``path``.
+
+        Parameters
+        ----------
+        path:
+            Location of the JSON file exported from Waze.
+
+        Returns
+        -------
+        list of dict
+            Story events with distance and duration details.
+
+        Notes
+        -----
+        Drives missing timestamps or distance are skipped. Segments with
+        missing coordinates are ignored when determining start and end points.
+        """
+
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+
+        drives = data.get("drives") or data.get("userTrips") or []
+        events: List[Dict[str, Any]] = []
+        for drive in drives:
+            start = self._parse_time(
+                drive.get("startTime") or drive.get("startTimeMillis")
+            )
+            end = self._parse_time(drive.get("endTime") or drive.get("endTimeMillis"))
+            length = drive.get("lengthMeters") or drive.get("length")
+            if not (start and end and length):
+                continue
+
+            duration_s = int((end - start).total_seconds())
+            distance_m = float(length)
+            start_point, end_point = self._extract_points(
+                drive.get("segments") or drive.get("path") or []
+            )
+            event: Dict[str, Any] = {
+                "event_id": f"waze_drive_{uuid4()}",
+                "timestamp": start.isoformat(),
+                "actor": "user",
+                "action": "drive",
+                "details": {
+                    "distance_m": distance_m,
+                    "duration_s": duration_s,
+                    "start_point": start_point,
+                    "end_point": end_point,
+                },
+            }
+            validate_story(event)
+            events.append(event)
+        return events
+
+    @staticmethod
+    def _parse_time(value: Any) -> Optional[datetime]:
+        """Parse timestamp from ISO string or milliseconds."""
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            try:
+                return datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+            except OSError:
+                return None
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _extract_points(
+        segments: List[Any],
+    ) -> Tuple[Optional[Dict[str, float]], Optional[Dict[str, float]]]:
+        """Return the first and last valid coordinates from ``segments``."""
+        points = [
+            {
+                "lat": seg.get("lat") or seg.get("latitude"),
+                "lon": seg.get("lon") or seg.get("longitude"),
+            }
+            for seg in segments
+            if isinstance(seg, dict)
+            and isinstance(seg.get("lat") or seg.get("latitude"), (int, float))
+            and isinstance(seg.get("lon") or seg.get("longitude"), (int, float))
+        ]
+        if not points:
+            return None, None
+        return points[0], points[-1]

--- a/tests/data/waze_sample.json
+++ b/tests/data/waze_sample.json
@@ -1,0 +1,22 @@
+{
+  "drives": [
+    {
+      "startTime": "2024-05-01T08:00:00Z",
+      "endTime": "2024-05-01T08:30:00Z",
+      "lengthMeters": 15000,
+      "segments": [
+        {"lat": 34.0, "lon": -118.0},
+        {"lat": 34.1, "lon": -118.1}
+      ]
+    },
+    {
+      "startTime": "2024-05-02T09:00:00Z",
+      "endTime": "2024-05-02T09:15:00Z",
+      "lengthMeters": 5000,
+      "segments": [
+        {"lat": null, "lon": -118.2},
+        {"foo": "bar"}
+      ]
+    }
+  ]
+}

--- a/tests/test_waze_connector.py
+++ b/tests/test_waze_connector.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from integrations.location.waze import WazeConnector
+
+
+def test_parse_drive_history(tmp_path):
+    sample = Path(__file__).parent / "data" / "waze_sample.json"
+    connector = WazeConnector()
+    events = connector.parse_drive_history(str(sample))
+    assert len(events) == 2
+
+    first = events[0]["details"]
+    assert first["distance_m"] == 15000.0
+    assert first["duration_s"] == 1800
+    assert first["start_point"] == {"lat": 34.0, "lon": -118.0}
+    assert first["end_point"] == {"lat": 34.1, "lon": -118.1}
+
+    second = events[1]["details"]
+    assert second["start_point"] is None
+    assert second["end_point"] is None


### PR DESCRIPTION
## Summary
- add WazeConnector for parsing Waze drive history into story events
- include sample export and tests handling missing coordinates
- allow committing sample Waze JSON data

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py tests/test_waze_connector.py -q`
- `cargo -Znext-lockfile-bump test` *(fails: use of unstable library feature 'ptr_from_ref')*


------
https://chatgpt.com/codex/tasks/task_e_68ae9441e6988322ab82c3caf6d0cf65