### PR TITLE
Disable auto-loading of pytest plugins

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,7 @@
+"""Test configuration that prevents auto-loading third-party pytest plugins."""
+
+import os
+
+# Prevent pytest from loading external plugins via entry points, which can
+# interfere with our isolated test environment.
+os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")


### PR DESCRIPTION
## Summary
- prevent auto-loading of third-party pytest plugins via `PYTEST_DISABLE_PLUGIN_AUTOLOAD`

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aef77749d883229d504c5c1243baf6