### PR TITLE
Fix timeline test imports

### DIFF
--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,6 +1,12 @@
 from datetime import datetime
 
 from utilities.timeline import (
+    bucket_by_day as util_bucket_by_day,
+    emails_for_day as util_emails_for_day,
+    index_emails_by_contact as util_index_emails_by_contact,
+    merge_event_streams as util_merge_event_streams,
+    step_index as util_step_index,
+)
 from tircorder_utils.timeline import (
     bucket_by_day,
     emails_for_day,


### PR DESCRIPTION
## Summary
- Import timeline helpers from both utilities and tircorder_utils modules with proper syntax

## Testing
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_timeline.py -q`
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aefd08203c832292a5148e343a2c88