### PR TITLE
Promote requests to core dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ ctranslate2==4.3.0
 faster-whisper==0.10.0
 librosa==0.10.1
 vaderSentiment==3.3.2
-# Optional dependencies
-# requests==2.32.3  # Needed for integrations.news_api and rule_check_client
+requests==2.32.3
 ofxparse==0.21
 qifparse==0.3.5
 piecash==1.1.0


### PR DESCRIPTION
## Summary
- Make `requests` a core requirement instead of optional

## Testing
- `pip install --break-system-packages -r requirements.txt` *(fails: No matching distribution found for ctranslate2==4.3.0)*
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aefcf42be88322bcd95d2f62317633