### PR TITLE
Add audio and utility dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,7 @@ networkx==3.3
 nltk==3.8.1
 PyYAML==6.0.1
 jsonschema==4.21.1
+pyaudio
+webrtcvad
+pynput
+colorama


### PR DESCRIPTION
## Summary
- add audio and input helper libraries to `requirements.txt`

## Testing
- `pip install --break-system-packages -r requirements.txt` *(fails: No matching distribution found for ctranslate2==4.3.0)*
- `PYENV_VERSION=3.10.17 pip install --break-system-packages pyaudio webrtcvad pynput colorama`
- `PYENV_VERSION=3.10.17 timeout 5s python jobbie_client_dual-capture.py` *(segmentation fault, ALSA errors)*
- `PYENV_VERSION=3.10.17 timeout 5s python jobbie_gpt_05-10-2024.py` *(IndentationError at line 241)*
- `PYENV_VERSION=3.10.17 PYTHONPATH=. pytest tests/test_calendar_utils.py -q`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aefcf988f48322a9ba3ca619aac154