### PR TITLE
Port database scan directory precedence onto current master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "assert_cmd"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +240,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +316,12 @@ dependencies = [
  "nix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "downcast-rs"
@@ -719,6 +757,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +966,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +1004,7 @@ dependencies = [
 name = "tircorder-rs"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "bevy_app",
  "bevy_ecs",
  "crossbeam-channel",
@@ -1039,6 +1111,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ hound = "3"
 # Use Bevy's ECS and application utilities for testing
 bevy_app = { version = "0.13", default-features = false }
 bevy_ecs = { version = "0.13", default-features = false }
+assert_cmd = "2"
 

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,6 +1,5 @@
 use crossbeam_channel::{Receiver, RecvTimeoutError};
 use ffmpeg_cli::{FfmpegBuilder, File, Parameter};
-use log::error;
 use std::ffi::OsStr;
 use std::io;
 use std::path::PathBuf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod converter;
 pub mod scanner;
 
-
 #[cfg(test)]
 mod tests;

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,5 +1,7 @@
 use crossbeam_channel::Sender;
 use std::collections::HashSet;
+use log::warn;
+use rusqlite::Connection;
 use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -12,6 +14,74 @@ use std::time::Duration;
 
 const AUDIO_EXTENSIONS: &[&str] = &["wav", "flac", "mp3", "ogg", "amr"];
 const TRANSCRIPT_EXTENSIONS: &[&str] = &["srt", "txt", "vtt", "json", "tsv"];
+
+/// Resolve scan directories from the database, falling back to CLI-specified
+/// paths when no database entries are found.
+///
+/// Database entries take precedence over CLI arguments. The `recordings_folders`
+/// table is created on demand if missing, and empty or unreadable databases
+/// cause the function to return the provided CLI paths with default flags
+/// (`ignore_transcribing = false`, `ignore_converting = false`).
+/// Returns the directories alongside a flag indicating whether the database was
+/// used.
+pub fn load_recording_dirs(
+    db_path: &Path,
+    cli_dirs: Vec<PathBuf>,
+) -> (Vec<(PathBuf, bool, bool)>, bool) {
+    let fallback: Vec<_> = cli_dirs
+        .into_iter()
+        .map(|path| (path, false, false))
+        .collect();
+
+    let conn = match Connection::open(db_path) {
+        Ok(conn) => conn,
+        Err(err) => {
+            warn!("Failed to open {}: {err}", db_path.display());
+            return (fallback, false);
+        }
+    };
+
+    if let Err(err) = conn.execute(
+        "CREATE TABLE IF NOT EXISTS recordings_folders (
+            id INTEGER PRIMARY KEY,
+            folder_path TEXT UNIQUE,
+            ignore_transcribing INTEGER DEFAULT 0,
+            ignore_converting INTEGER DEFAULT 0
+        )",
+        [],
+    ) {
+        warn!("Failed to ensure recordings_folders table exists: {err}");
+        return (fallback, false);
+    }
+
+    let mut stmt = match conn.prepare(
+        "SELECT folder_path, ignore_transcribing, ignore_converting FROM recordings_folders",
+    ) {
+        Ok(stmt) => stmt,
+        Err(err) => {
+            warn!("Failed to prepare folder query: {err}");
+            return (fallback, false);
+        }
+    };
+
+    let db_dirs: rusqlite::Result<Vec<_>> = stmt
+        .query_map([], |row| {
+            let path: String = row.get(0)?;
+            let ignore_transcribing: i64 = row.get(1)?;
+            let ignore_converting: i64 = row.get(2)?;
+            Ok((
+                PathBuf::from(path),
+                ignore_transcribing != 0,
+                ignore_converting != 0,
+            ))
+        })
+        .and_then(|rows| rows.collect());
+
+    match db_dirs {
+        Ok(dirs) if !dirs.is_empty() => (dirs, true),
+        _ => (fallback, false),
+    }
+}
 
 /// Scan the provided directories once and return audio files queued for
 /// transcription and conversion.
@@ -70,13 +140,12 @@ pub fn scan_directories(dirs: Vec<(PathBuf, bool, bool)>) -> (Vec<PathBuf>, Vec<
 /// Start a background scanner that periodically inspects directories and queues
 /// new audio files for transcription and conversion until `shutdown` is set.
 pub fn start_scanner(
-    dirs: Vec<PathBuf>,
+    dirs: Vec<(PathBuf, bool, bool)>,
     tx_transcribe: Sender<PathBuf>,
     tx_convert: Sender<PathBuf>,
     shutdown: Arc<AtomicBool>,
 ) -> Result<thread::JoinHandle<()>, io::Error> {
-    let scan_dirs: Vec<(PathBuf, bool, bool)> =
-        dirs.into_iter().map(|d| (d, false, false)).collect();
+    let scan_dirs = dirs;
 
     Ok(thread::spawn(move || {
         let mut dispatched_transcribe: HashSet<PathBuf> = HashSet::new();

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use hound::{SampleFormat, WavSpec, WavWriter};
+use std::path::Path;
 
 pub fn write_dummy_wav(path: &Path) {
     let spec = WavSpec {

--- a/src/tests/integration_scan.rs
+++ b/src/tests/integration_scan.rs
@@ -1,0 +1,79 @@
+use assert_cmd::Command;
+use crossbeam_channel::unbounded;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tempfile::tempdir;
+
+use crate::scanner::{load_recording_dirs, start_scanner};
+use crate::tests::common::write_dummy_wav;
+
+#[test]
+fn scan_uses_db_entries_without_cli_args() {
+    let workspace = tempdir().unwrap();
+    let recordings = workspace.path().join("recordings");
+    std::fs::create_dir_all(&recordings).unwrap();
+    let wav = recordings.join("sample.wav");
+    write_dummy_wav(&wav);
+
+    #[allow(deprecated)]
+    let mut init = Command::cargo_bin("tircorder-rs").unwrap();
+    init.current_dir(workspace.path())
+        .args(["init", recordings.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let (dirs, used_db) = load_recording_dirs(&workspace.path().join("state.db"), Vec::new());
+    assert!(used_db, "Expected database entries to be used when present");
+    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs[0].0, recordings);
+
+    let (tx_transcribe, rx_transcribe) = unbounded();
+    let (tx_convert, rx_convert) = unbounded();
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let handle = start_scanner(dirs, tx_transcribe, tx_convert, shutdown.clone()).unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+
+    let transcribed: Vec<_> = rx_transcribe.try_iter().collect();
+    let converted: Vec<_> = rx_convert.try_iter().collect();
+
+    assert!(transcribed.contains(&wav));
+    assert!(converted.contains(&wav));
+
+    shutdown.store(true, Ordering::SeqCst);
+    handle.join().unwrap();
+}
+
+#[test]
+fn cli_paths_used_when_database_empty() {
+    let workspace = tempdir().unwrap();
+    let recordings = workspace.path().join("recordings");
+    std::fs::create_dir_all(&recordings).unwrap();
+    let wav = recordings.join("fallback.wav");
+    write_dummy_wav(&wav);
+
+    let (dirs, used_db) =
+        load_recording_dirs(&workspace.path().join("state.db"), vec![recordings.clone()]);
+    assert!(!used_db, "Database should not be used when no rows exist");
+    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs[0].0, recordings);
+
+    let (tx_transcribe, rx_transcribe) = unbounded();
+    let (tx_convert, rx_convert) = unbounded();
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let handle = start_scanner(dirs, tx_transcribe, tx_convert, shutdown.clone()).unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+
+    let transcribed: Vec<_> = rx_transcribe.try_iter().collect();
+    let converted: Vec<_> = rx_convert.try_iter().collect();
+
+    assert!(transcribed.contains(&wav));
+    assert!(converted.contains(&wav));
+
+    shutdown.store(true, Ordering::SeqCst);
+    handle.join().unwrap();
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod common;
-mod scanner;
 mod converter;
+mod integration_scan;
+mod scanner;

--- a/src/tests/scanner.rs
+++ b/src/tests/scanner.rs
@@ -35,7 +35,7 @@ fn scan_directories_respects_ignore_flags() {
     let shutdown = Arc::new(AtomicBool::new(false));
 
     let handle = start_scanner(
-        vec![dir1.path().to_path_buf()],
+        vec![(dir1.path().to_path_buf(), false, false)],
         tx_transcribe,
         tx_convert,
         shutdown.clone(),
@@ -75,7 +75,7 @@ fn start_scanner_dispatches_new_files() {
     let (tx_convert, rx_convert) = unbounded();
 
     let handle = start_scanner(
-        vec![dir.path().to_path_buf()],
+        vec![(dir.path().to_path_buf(), false, false)],
         tx_transcribe,
         tx_convert,
         shutdown.clone(),


### PR DESCRIPTION
Forward-port of #101 onto current master. Keeps the current incremental scanner behavior while restoring database-driven scan directory precedence and the accompanying integration coverage.\n\nValidation:\n- cargo test -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recording directories are now persisted to a local database and automatically reused across scans.
  * Database-stored directories take precedence over CLI arguments for convenience.
  * CLI directories serve as a fallback when no saved directories exist.

* **Improvements**
  * Enhanced validation with clearer error messaging for empty directory lists.

* **Tests**
  * Added integration tests for directory discovery and database persistence workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->